### PR TITLE
Directly destroy drivers instead of deferring

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -44,7 +44,7 @@ func OutputResult(result *types.TestResult, isQuiet bool) string {
 func Banner(filename string) string {
 	fileStr := fmt.Sprintf("====== Test file: %s ======", filepath.Base(filename))
 	bannerStr := strings.Repeat("=", len(fileStr))
-	return purple(bannerStr) + "\n" + purple(fileStr) + "\n" + purple(bannerStr)
+	return purple(bannerStr) + "\n" + purple(fileStr) + "\n" + purple(bannerStr) + "\n"
 }
 
 func FinalResults(result types.SummaryObject) string {

--- a/pkg/types/v1/structure.go
+++ b/pkg/types/v1/structure.go
@@ -63,23 +63,22 @@ func (st *StructureTest) RunCommandTests(channel chan interface{}) {
 		}
 		driver, err := st.NewDriver()
 		if err != nil {
-			ctc_lib.Log.Error(err.Error())
-			continue
+			ctc_lib.Log.Fatal(err.Error())
 		}
-		defer driver.Destroy()
 		vars := append(st.GlobalEnvVars, test.EnvVars...)
 		if err = driver.Setup(vars, test.Setup); err != nil {
 			ctc_lib.Log.Error(err.Error())
+			driver.Destroy()
 			continue
 		}
 		defer func() {
 			if err := driver.Teardown(vars, test.Teardown); err != nil {
 				ctc_lib.Log.Error(err.Error())
 			}
+			driver.Destroy()
 		}()
 		channel <- test.Run(driver)
 	}
-
 }
 
 func (st *StructureTest) RunFileExistenceTests(channel chan interface{}) {
@@ -90,10 +89,10 @@ func (st *StructureTest) RunFileExistenceTests(channel chan interface{}) {
 		}
 		driver, err := st.NewDriver()
 		if err != nil {
-			ctc_lib.Log.Fatalf(err.Error())
+			ctc_lib.Log.Fatal(err.Error())
 		}
-		defer driver.Destroy()
 		channel <- test.Run(driver)
+		driver.Destroy()
 	}
 
 }
@@ -105,11 +104,10 @@ func (st *StructureTest) RunFileContentTests(channel chan interface{}) {
 		}
 		driver, err := st.NewDriver()
 		if err != nil {
-			ctc_lib.Log.Error(err)
-			ctc_lib.Log.Error(err.Error())
+			ctc_lib.Log.Fatal(err.Error())
 		}
-		defer driver.Destroy()
 		channel <- test.Run(driver)
+		driver.Destroy()
 	}
 }
 
@@ -117,10 +115,9 @@ func (st *StructureTest) RunLicenseTests(channel chan interface{}) {
 	for _, test := range st.LicenseTests {
 		driver, err := st.NewDriver()
 		if err != nil {
-			ctc_lib.Log.Error(err.Error())
-			continue
+			ctc_lib.Log.Fatal(err.Error())
 		}
-		defer driver.Destroy()
 		channel <- test.Run(driver)
+		driver.Destroy()
 	}
 }

--- a/pkg/types/v2/structure.go
+++ b/pkg/types/v2/structure.go
@@ -90,8 +90,8 @@ func (st *StructureTest) RunFileExistenceTests(channel chan interface{}) {
 		if err != nil {
 			ctc_lib.Log.Fatalf(err.Error())
 		}
-		defer driver.Destroy()
 		channel <- test.Run(driver)
+		driver.Destroy()
 	}
 }
 
@@ -103,30 +103,29 @@ func (st *StructureTest) RunFileContentTests(channel chan interface{}) {
 		}
 		driver, err := st.NewDriver()
 		if err != nil {
-			ctc_lib.Log.Error(err)
-			ctc_lib.Log.Error(err.Error())
+			ctc_lib.Log.Fatal(err.Error())
 		}
 		channel <- test.Run(driver)
+		driver.Destroy()
 	}
 }
 
 func (st *StructureTest) RunMetadataTests(channel chan interface{}) {
 	driver, err := st.NewDriver()
 	if err != nil {
-		ctc_lib.Log.Error(err.Error())
+		ctc_lib.Log.Fatal(err.Error())
 	}
-	defer driver.Destroy()
 	channel <- st.MetadataTest.Run(driver)
+	driver.Destroy()
 }
 
 func (st *StructureTest) RunLicenseTests(channel chan interface{}) {
 	for _, test := range st.LicenseTests {
 		driver, err := st.NewDriver()
 		if err != nil {
-			ctc_lib.Log.Error(err.Error())
-			continue
+			ctc_lib.Log.Fatal(err.Error())
 		}
-		defer driver.Destroy()
 		channel <- test.Run(driver)
+		driver.Destroy()
 	}
 }


### PR DESCRIPTION
Since we were calling `defer driver.Destroy()` in a loop, these calls were piling up until all tests finished running, meaning that many drivers were being created alongside each other. This means that many image filesystems were being unpacked at the same time causing a ton of disk space to be used. This should make it so at most one unpacked imageFS exists at any given time on the host FS.

Also, apparently nesting defer calls causing orders of magnitude slower program execution, so that's a win as well.

Fixed a few wrong log levels while I was in here.