### PR TITLE
Various run and output fixes

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,7 @@ var RootCmd = &ctc_lib.ContainerToolListCommand{
 the structure of a container image.
 These tests can be used to check the output of commands in an image,
 as well as verify metadata and contents of the filesystem.`,
+			SilenceErrors: true,
 		},
 		Phase:           "stable",
 		DefaultTemplate: "{{.}}",

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -72,12 +72,12 @@ var TestCmd = &ctc_lib.ContainerToolListCommand{
 		totalPass := 0
 		totalFail := 0
 		errStrings := make([]string, 0)
-		var err error = nil
+		var err error
 		for _, r := range list {
 			value, ok := r.(*unversioned.TestResult)
 			if !ok {
-				errStrings = append(errStrings, fmt.Sprintf("UnExpected Value %v in List.", value))
-				ctc_lib.Log.Errorf("Unexpected value %v in List.", value)
+				errStrings = append(errStrings, fmt.Sprintf("unexpected value %v in list", value))
+				ctc_lib.Log.Errorf("unexpected value %v in list", value)
 				continue
 			}
 			if value.IsPass() {
@@ -94,11 +94,10 @@ var TestCmd = &ctc_lib.ContainerToolListCommand{
 		}
 
 		return unversioned.SummaryObject{
-				Total: totalFail + totalPass,
-				Pass:  totalPass,
-				Fail:  totalFail,
-			},
-			err
+			Total: totalFail + totalPass,
+			Pass:  totalPass,
+			Fail:  totalFail,
+		}, err
 	},
 }
 
@@ -129,8 +128,8 @@ func RunTests() {
 		Channel <- output.Banner(file)
 		tests, err := Parse(file)
 		if err != nil {
-			// Continue with other config files
 			ctc_lib.Log.Errorf("Error parsing config file: %s", err)
+			continue // Continue with other config files
 		}
 		tests.RunAll(Channel, file)
 	}
@@ -227,7 +226,6 @@ func Run() {
 	if err != nil {
 		ctc_lib.Log.Fatal(err.Error())
 	}
-	ctc_lib.Log.Infof("Using driver %s\n", driver)
 	go RunTests()
 }
 

--- a/pkg/types/v2/metadata.go
+++ b/pkg/types/v2/metadata.go
@@ -33,6 +33,16 @@ type MetadataTest struct {
 	Labels       []types.Label  `yaml:"labels"`
 }
 
+func (mt MetadataTest) IsEmpty() bool {
+	return len(mt.Env) == 0 &&
+		len(mt.ExposedPorts) == 0 &&
+		mt.Entrypoint == nil &&
+		mt.Cmd == nil &&
+		mt.Workdir == "" &&
+		len(mt.Volumes) == 0 &&
+		len(mt.Labels) == 0
+}
+
 func (mt MetadataTest) LogName() string {
 	return "Metadata Test"
 }

--- a/pkg/types/v2/structure.go
+++ b/pkg/types/v2/structure.go
@@ -112,6 +112,13 @@ func (st *StructureTest) RunFileContentTests(channel chan interface{}) {
 }
 
 func (st *StructureTest) RunMetadataTests(channel chan interface{}) {
+	if st.MetadataTest.IsEmpty() {
+		ctc_lib.Log.Debug("Skipping empty metadata test")
+		return
+	}
+	if err := st.MetadataTest.Validate(); err != nil {
+		return
+	}
 	driver, err := st.NewDriver()
 	if err != nil {
 		ctc_lib.Log.Fatal(err.Error())


### PR DESCRIPTION
* don't run tests if config isn't parsed correctly
* validate metadata test before running
* fix output format and use buffers to write strings
* remove extraneous log statements