### PR TITLE
Set global env vars in all tests, and support substitutions

### DIFF
--- a/pkg/drivers/driver.go
+++ b/pkg/drivers/driver.go
@@ -15,6 +15,7 @@
 package drivers
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -37,7 +38,9 @@ type Driver interface {
 	Setup(envVars []unversioned.EnvVar, fullCommands [][]string) error
 
 	// Teardown is optional and is only used in the host driver
-	Teardown(envVars []unversioned.EnvVar, fullCommands [][]string) error
+	Teardown(fullCommands [][]string) error
+
+	SetEnv(envVars []unversioned.EnvVar) error
 
 	// given an array of command parts, construct a full command and execute it against the
 	// current environment. a list of environment variables can be passed to be set in the
@@ -72,10 +75,18 @@ func InitDriverImpl(driver string) func(DriverConfig) (Driver, error) {
 
 func convertSliceToMap(slice []string) map[string]string {
 	// convert slice to map for processing
-	trgtMap := make(map[string]string)
+	res := make(map[string]string)
 	for _, slicePair := range slice {
 		pair := strings.Split(slicePair, "=")
-		trgtMap[pair[0]] = pair[1]
+		res[pair[0]] = pair[1]
 	}
-	return trgtMap
+	return res
+}
+
+func convertMapToSlice(m map[string]string) []string {
+	res := []string{}
+	for k, v := range m {
+		res = append(res, fmt.Sprintf("%s=%s", k, v))
+	}
+	return res
 }

--- a/pkg/types/v1/command.go
+++ b/pkg/types/v1/command.go
@@ -70,7 +70,11 @@ func (ct *CommandTest) Validate() error {
 
 func (ct *CommandTest) Run(driver drivers.Driver) *types.TestResult {
 	ctc_lib.Log.Debug(ct.LogName())
-	stdout, stderr, exitcode, err := driver.ProcessCommand(ct.EnvVars, ct.Command)
+	config, err := driver.GetConfig()
+	if err != nil {
+		ctc_lib.Log.Errorf("error retrieving image config: %s", err.Error())
+	}
+	stdout, stderr, exitcode, err := driver.ProcessCommand(ct.EnvVars, utils.SubstituteEnvVars(ct.Command, config.Env))
 	result := &types.TestResult{
 		Name:   ct.LogName(),
 		Pass:   true,

--- a/pkg/types/v1/structure.go
+++ b/pkg/types/v1/structure.go
@@ -72,7 +72,7 @@ func (st *StructureTest) RunCommandTests(channel chan interface{}) {
 			continue
 		}
 		defer func() {
-			if err := driver.Teardown(vars, test.Teardown); err != nil {
+			if err := driver.Teardown(test.Teardown); err != nil {
 				ctc_lib.Log.Error(err.Error())
 			}
 			driver.Destroy()

--- a/pkg/types/v2/command.go
+++ b/pkg/types/v2/command.go
@@ -75,7 +75,11 @@ func (ct *CommandTest) LogName() string {
 
 func (ct *CommandTest) Run(driver drivers.Driver) *types.TestResult {
 	ctc_lib.Log.Debug(ct.LogName())
-	fullCommand := append([]string{ct.Command}, ct.Args...)
+	config, err := driver.GetConfig()
+	if err != nil {
+		ctc_lib.Log.Errorf("error retrieving image config: %s", err.Error())
+	}
+	fullCommand := utils.SubstituteEnvVars(append([]string{ct.Command}, ct.Args...), config.Env)
 	stdout, stderr, exitcode, err := driver.ProcessCommand(ct.EnvVars, fullCommand)
 	result := &types.TestResult{
 		Name:   ct.LogName(),

--- a/pkg/types/v2/file_existence.go
+++ b/pkg/types/v2/file_existence.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/container-structure-test/pkg/drivers"
 	types "github.com/GoogleContainerTools/container-structure-test/pkg/types/unversioned"
+	"github.com/GoogleContainerTools/container-structure-test/pkg/utils"
 )
 
 type FileExistenceTest struct {
@@ -54,7 +55,11 @@ func (ft FileExistenceTest) Run(driver drivers.Driver) *types.TestResult {
 	}
 	ctc_lib.Log.Info(ft.LogName())
 	var info os.FileInfo
-	info, err := driver.StatFile(ft.Path)
+	config, err := driver.GetConfig()
+	if err != nil {
+		ctc_lib.Log.Errorf("error retrieving image config: %s", err.Error())
+	}
+	info, err = driver.StatFile(utils.SubstituteEnvVar(ft.Path, config.Env))
 	if info == nil {
 		result.Errorf(errors.Wrap(err, "Error examining file in container").Error())
 		result.Fail()

--- a/pkg/types/v2/metadata.go
+++ b/pkg/types/v2/metadata.go
@@ -114,12 +114,7 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 			result.Errorf("Image Cmd %v does not match expected Cmd: %v", imageConfig.Cmd, *mt.Cmd)
 			result.Fail()
 		} else if len(*mt.Cmd) > 0 {
-			fmt.Printf("config length: %d\n", len(*mt.Cmd))
-			fmt.Printf("image command length: %d\n", len(imageConfig.Cmd))
-			fmt.Printf("single config command entry: %s\n", (*mt.Cmd)[0])
-			fmt.Printf("single image command entry: %s\n", imageConfig.Cmd[0])
 			for i := range *mt.Cmd {
-				fmt.Println(i)
 				if (*mt.Cmd)[i] != imageConfig.Cmd[i] {
 					result.Errorf("Image config Cmd does not match expected value: %s", *mt.Cmd)
 					result.Fail()

--- a/pkg/types/v2/structure.go
+++ b/pkg/types/v2/structure.go
@@ -67,13 +67,16 @@ func (st *StructureTest) RunCommandTests(channel chan interface{}) {
 			continue
 		}
 		defer driver.Destroy()
-		vars := append(st.GlobalEnvVars, test.EnvVars...)
-		if err = driver.Setup(vars, test.Setup); err != nil {
+		if err = driver.SetEnv(st.GlobalEnvVars); err != nil {
+			ctc_lib.Log.Error(err.Error())
+			continue
+		}
+		if err = driver.Setup(test.EnvVars, test.Setup); err != nil {
 			ctc_lib.Log.Error(err.Error())
 			continue
 		}
 		defer func() {
-			if err := driver.Teardown(vars, test.Teardown); err != nil {
+			if err := driver.Teardown(test.Teardown); err != nil {
 				ctc_lib.Log.Error(err.Error())
 			}
 		}()
@@ -91,6 +94,10 @@ func (st *StructureTest) RunFileExistenceTests(channel chan interface{}) {
 		if err != nil {
 			ctc_lib.Log.Fatalf(err.Error())
 		}
+		if err = driver.SetEnv(st.GlobalEnvVars); err != nil {
+			ctc_lib.Log.Error(err.Error())
+			continue
+		}
 		channel <- test.Run(driver)
 		driver.Destroy()
 	}
@@ -105,6 +112,10 @@ func (st *StructureTest) RunFileContentTests(channel chan interface{}) {
 		driver, err := st.NewDriver()
 		if err != nil {
 			ctc_lib.Log.Fatal(err.Error())
+		}
+		if err = driver.SetEnv(st.GlobalEnvVars); err != nil {
+			ctc_lib.Log.Error(err.Error())
+			continue
 		}
 		channel <- test.Run(driver)
 		driver.Destroy()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 
 	"github.com/GoogleCloudPlatform/runtimes-common/ctc_lib"
@@ -74,4 +75,20 @@ func ValueInList(target string, list []string) bool {
 		}
 	}
 	return false
+}
+
+func SubstituteEnvVar(arg string, env map[string]string) string {
+	f := func(key string) string {
+		return env[key]
+	}
+	subbed := os.Expand(arg, f)
+	return subbed
+}
+
+func SubstituteEnvVars(args []string, env map[string]string) []string {
+	finalArgs := []string{}
+	for _, arg := range args {
+		finalArgs = append(finalArgs, SubstituteEnvVar(arg, env))
+	}
+	return finalArgs
 }


### PR DESCRIPTION
This adds support for performing inline environment variable substitutions directly in the config, for all test types. Global environment variables will now be set in all tests, and substitutions will be performed on all fields provided in the test config before running the tests. For example, this is now a valid test config:
```
schemaVersion: "2.0.0"

globalEnvVars:
  - key: "FOO"
    value: "/usr/bin"

commandTests:
  - name: Path env var
    command: "echo"
    args: ["$PATH"]
    expectedOutput: [".*/usr/bin.*"]

fileExistenceTests:
  - name: Python with env vars
    path: "$FOO/python2.7"
    shouldExist: true
```

Fixes #107 
Fixes #98 