### PR TITLE
Don't allow regexes when checking env/labels in metadata test

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ of these checks are optional.
 #### Supported Fields:
 
 - Env (`[]EnvVar`): A list of environment variable key/value pairs that should be set
-in the container.  Supports regexes for values.
+in the container.
 - Labels (`[]Label`): A list of image labels key/value pairs that should be set on the
-container.  Supports regexes for values.
+container.
 - Entrypoint (`[]string`): The entrypoint of the container
 - Cmd (`[]string`): The CMD specified in the container.
 - Exposed Ports (`[]string`): The ports exposed in the container.

--- a/pkg/types/v2/metadata.go
+++ b/pkg/types/v2/metadata.go
@@ -85,9 +85,9 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 	}
 
 	for _, pair := range mt.Env {
-		if act_val, has_key := imageConfig.Env[pair.Key]; has_key {
-			if !utils.CompileAndRunRegex(pair.Value, act_val, true) {
-				result.Errorf("env var %s value does not match expected value: %s", pair.Key, pair.Value)
+		if val, ok := imageConfig.Env[pair.Key]; ok {
+			if pair.Value != val {
+				result.Errorf("env var %s value %s does not match expected value: %s", pair.Key, val, pair.Value)
 				result.Fail()
 			}
 		} else {
@@ -97,16 +97,15 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 	}
 
 	for _, pair := range mt.Labels {
-		if act_val, has_key := imageConfig.Labels[pair.Key]; has_key {
-			if !utils.CompileAndRunRegex(pair.Value, act_val, true) {
-				result.Errorf("label %s value does not match expected value: %s", pair.Key, pair.Value)
+		if val, ok := imageConfig.Labels[pair.Key]; ok {
+			if pair.Value != val {
+				result.Errorf("label %s value %s does not match expected value: %s", pair.Key, val, pair.Value)
 				result.Fail()
 			}
 		} else {
 			result.Errorf("label %s not found in image metadata", pair.Key)
 			result.Fail()
 		}
-
 	}
 
 	if mt.Cmd != nil {

--- a/tests/Dockerfile.metadata
+++ b/tests/Dockerfile.metadata
@@ -1,7 +1,8 @@
 FROM gcr.io/google-appengine/debian8:latest
 
 ENV SOME_KEY="SOME_VAL" \
-    EMPTY_VAR=""
+    EMPTY_VAR="" \
+    FOO_BAR="FOO\:BAR"
 
 LABEL localnet.localdomain.commit_hash="0123456789abcdef0123456789abcdef01234567" \
       localnet.my-domain.my-label="my test label" \

--- a/tests/debian_metadata_test.yaml
+++ b/tests/debian_metadata_test.yaml
@@ -5,10 +5,10 @@ metadataTest:
     value: 'SOME_VAL'
   - key: 'EMPTY_VAR'
     value: ''
+  - key: 'FOO_BAR'
+    value: 'FOO\:BAR'
   labels:
   - key: 'localnet.localdomain.commit_hash'
     value: '0123456789abcdef0123456789abcdef01234567'
-  - key: 'localnet.my-domain.my-label'
-    value: 'my .+ label'
   - key: 'label-with-empty-val'
     value: ''


### PR DESCRIPTION
There are valid unix environment variables that create regexes that don't match themselves in Golang (i.e. `a\"b`). It's not really useful to use regexes to check for environment variable values anyway, so removing this in favor of direct string comparison.