### PR TITLE
Remove intermediate env var container

### DIFF
--- a/pkg/drivers/docker_driver.go
+++ b/pkg/drivers/docker_driver.go
@@ -83,6 +83,7 @@ func (d *DockerDriver) SetEnv(envVars []unversioned.EnvVar) error {
 	if err != nil {
 		return errors.Wrap(err, "Error creating container")
 	}
+	defer d.removeContainer(container.ID)
 	image, err := d.cli.CommitContainer(docker.CommitContainerOptions{
 		Container: container.ID,
 	})


### PR DESCRIPTION
This removes the intermediate container created to set environment variables.

re-fixes #39 