### PR TITLE
Fail immediately if entrypoint lengths do not match

### DIFF
--- a/pkg/types/v2/metadata.go
+++ b/pkg/types/v2/metadata.go
@@ -126,11 +126,12 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 		if len(*mt.Entrypoint) != len(imageConfig.Entrypoint) {
 			result.Errorf("Image entrypoint %v does not match expected entrypoint: %v", imageConfig.Entrypoint, *mt.Entrypoint)
 			result.Fail()
-		}
-		for i := range *mt.Entrypoint {
-			if (*mt.Entrypoint)[i] != imageConfig.Entrypoint[i] {
-				result.Errorf("Image config entrypoint does not match expected value: %s", *mt.Entrypoint)
-				result.Fail()
+		} else {
+			for i := range *mt.Entrypoint {
+				if (*mt.Entrypoint)[i] != imageConfig.Entrypoint[i] {
+					result.Errorf("Image config entrypoint does not match expected value: %s", *mt.Entrypoint)
+					result.Fail()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This was causing a panic if the entrypoint lengths were not the same.