### PR TITLE
Fail tests properly when validation fails

### DIFF
--- a/pkg/types/v2/file_content.go
+++ b/pkg/types/v2/file_content.go
@@ -31,14 +31,20 @@ type FileContentTest struct {
 	ExcludedContents []string `yaml:"excludedContents"` // list of excluded contents of file
 }
 
-func (ft FileContentTest) Validate() error {
+func (ft FileContentTest) Validate(channel chan interface{}) bool {
+	res := &types.TestResult{}
 	if ft.Name == "" {
-		return fmt.Errorf("Please provide a valid name for every test")
+		res.Error("Please provide a valid name for every test")
 	}
+	res.Name = ft.Name
 	if ft.Path == "" {
-		return fmt.Errorf("Please provide a valid file path for test %s", ft.Name)
+		res.Errorf("Please provide a valid file path for test %s", ft.Name)
 	}
-	return nil
+	if len(res.Errors) > 0 {
+		channel <- res
+		return false
+	}
+	return true
 }
 
 func (ft FileContentTest) LogName() string {

--- a/pkg/types/v2/file_existence.go
+++ b/pkg/types/v2/file_existence.go
@@ -52,14 +52,20 @@ func (fe *FileExistenceTest) UnmarshalYAML(unmarshal func(interface{}) error) er
 	return nil
 }
 
-func (ft FileExistenceTest) Validate() error {
+func (ft FileExistenceTest) Validate(channel chan interface{}) bool {
+	res := &types.TestResult{}
 	if ft.Name == "" {
-		return fmt.Errorf("Please provide a valid name for every test")
+		res.Errorf("Please provide a valid name for every test")
 	}
+	res.Name = ft.Name
 	if ft.Path == "" {
-		fmt.Errorf("Please provide a valid file path for test %s", ft.Name)
+		res.Errorf("Please provide a valid file path for test %s", ft.Name)
 	}
-	return nil
+	if len(res.Errors) > 0 {
+		channel <- res
+		return false
+	}
+	return true
 }
 
 func (ft FileExistenceTest) LogName() string {

--- a/pkg/types/v2/metadata.go
+++ b/pkg/types/v2/metadata.go
@@ -15,8 +15,6 @@
 package v2
 
 import (
-	"fmt"
-
 	"github.com/GoogleCloudPlatform/runtimes-common/ctc_lib"
 	"github.com/GoogleContainerTools/container-structure-test/pkg/drivers"
 	types "github.com/GoogleContainerTools/container-structure-test/pkg/types/unversioned"
@@ -47,28 +45,35 @@ func (mt MetadataTest) LogName() string {
 	return "Metadata Test"
 }
 
-func (mt MetadataTest) Validate() error {
+func (mt MetadataTest) Validate(channel chan interface{}) bool {
+	res := &types.TestResult{
+		Name: mt.LogName(),
+	}
 	for _, envVar := range mt.Env {
 		if envVar.Key == "" {
-			return fmt.Errorf("Environment variable key cannot be empty")
+			res.Error("Environment variable key cannot be empty")
 		}
 	}
 	for _, label := range mt.Labels {
 		if label.Key == "" {
-			return fmt.Errorf("Label key cannot be empty")
+			res.Error("Label key cannot be empty")
 		}
 	}
 	for _, port := range mt.ExposedPorts {
 		if port == "" {
-			return fmt.Errorf("Port cannot be empty")
+			res.Error("Port cannot be empty")
 		}
 	}
 	for _, volume := range mt.Volumes {
 		if volume == "" {
-			return fmt.Errorf("Volume cannot be empty")
+			res.Error("Volume cannot be empty")
 		}
 	}
-	return nil
+	if len(res.Errors) > 0 {
+		channel <- res
+		return false
+	}
+	return true
 }
 
 func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {


### PR DESCRIPTION
Before, we only logged an error when validation (or anything involved in the test setup) failed, causing some runs with failed tests to exit with code 0, breaking some CI flows. This will return a failed test result whenever anything in the test run process fails.

Fixes #146 