### PR TITLE
Check ownership of a file or directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ are checked. These tests can also be used to ensure a file or directory is
 directory should exist in the file system
 - Permissions (`string`, *optional*): The expected Unix permission string (e.g.
   drwxrwxrwx) of the files or directory.
+- Uid (`int`, *optional*): The expected Unix user ID that has access to the file
+  or directory.
+- Gid (`int`, *optional*): The expected Unix group ID that has access to the
+  file or directory.
 
 Example:
 ```yaml
@@ -148,6 +152,8 @@ fileExistenceTests:
   path: '/'
   shouldExist: true
   permissions: '-rw-r--r--'
+  uid: 1000
+  gid: 1000
 ```
 
 ## File Content Tests

--- a/pkg/types/v2/file_existence.go
+++ b/pkg/types/v2/file_existence.go
@@ -15,6 +15,7 @@
 package v2
 
 import (
+	"archive/tar"
 	"fmt"
 	"os"
 
@@ -26,11 +27,15 @@ import (
 	"github.com/GoogleContainerTools/container-structure-test/pkg/utils"
 )
 
+var defaultOwnership = -1
+
 type FileExistenceTest struct {
 	Name        string `yaml:"name"`        // name of test
 	Path        string `yaml:"path"`        // file to check existence of
 	ShouldExist bool   `yaml:"shouldExist"` // whether or not the file should exist
 	Permissions string `yaml:"permissions"` // expected Unix permission string of the file, e.g. drwxrwxrwx
+	Uid         int    `yaml:"uid"`         // ID of the owner of the file
+	Gid         int    `yaml:"gid"`         // ID of the group of the file
 }
 
 func (fe FileExistenceTest) MarshalYAML() (interface{}, error) {
@@ -43,6 +48,8 @@ func (fe *FileExistenceTest) UnmarshalYAML(unmarshal func(interface{}) error) er
 	type feAlias FileExistenceTest
 	feTest := feAlias{
 		ShouldExist: true,
+		Uid:         defaultOwnership,
+		Gid:         defaultOwnership,
 	}
 	err := unmarshal(&feTest)
 	if err != nil {
@@ -101,6 +108,22 @@ func (ft FileExistenceTest) Run(driver drivers.Driver) *types.TestResult {
 		perms := info.Mode()
 		if perms.String() != ft.Permissions {
 			result.Errorf("%s has incorrect permissions. Expected: %s, Actual: %s", ft.Path, ft.Permissions, perms.String())
+			result.Fail()
+		}
+	}
+	if ft.Uid != defaultOwnership || ft.Gid != defaultOwnership {
+		header, ok := info.Sys().(*tar.Header)
+		if ok {
+			if ft.Uid != defaultOwnership && header.Uid != ft.Uid {
+				result.Errorf("%s has incorrect user ownership. Expected: %d, Actual: %d", ft.Path, ft.Uid, header.Uid)
+				result.Fail()
+			}
+			if ft.Gid != defaultOwnership && header.Gid != ft.Gid {
+				result.Errorf("%s has incorrect group ownership. Expected: %d, Actual: %d", ft.Path, ft.Gid, header.Gid)
+				result.Fail()
+			}
+		} else {
+			result.Errorf("Error checking ownership of file %s", ft.Path)
 			result.Fail()
 		}
 	}

--- a/tests/debian_test.yaml
+++ b/tests/debian_test.yaml
@@ -25,6 +25,8 @@ fileExistenceTests:
 - name: 'Root'
   path: '/'
   shouldExist: true
+  uid: 0
+  gid: 0
 - name: 'Netbase'
   path: '/etc/protocols'
   shouldExist: true


### PR DESCRIPTION
Adds two new fields `uid` and `gid` to a FileExistenceTest to ensure
that a file or directory is owned by a specific user or group.
Both fields are optional.