### PR TITLE
Fail entire test run if one config file fails

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -129,7 +129,11 @@ func RunTests() {
 		Channel <- output.Banner(file)
 		tests, err := Parse(file)
 		if err != nil {
-			ctc_lib.Log.Errorf("Error parsing config file: %s", err)
+			Channel <- &unversioned.TestResult{
+				Errors: []string{
+					fmt.Sprintf("error parsing config file: %s", err),
+				},
+			}
 			continue // Continue with other config files
 		}
 		tests.RunAll(Channel, file)

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -49,7 +49,7 @@ func Banner(filename string) string {
 	var strBuffer bytes.Buffer
 	fileStr := fmt.Sprintf("====== Test file: %s ======", filepath.Base(filename))
 	bannerLength = len(fileStr)
-	strBuffer.WriteString(strings.Repeat("=", bannerLength) + "\n")
+	strBuffer.WriteString("\n" + strings.Repeat("=", bannerLength) + "\n")
 	strBuffer.WriteString(fileStr + "\n")
 	strBuffer.WriteString(strings.Repeat("=", bannerLength) + "\n")
 	return purple(strBuffer.String())
@@ -73,9 +73,9 @@ func FinalResults(result types.SummaryObject) string {
 	strBuffer.WriteString(lightRed(fmt.Sprintf("Failures:    %d\n", result.Fail)))
 	strBuffer.WriteString(cyan(fmt.Sprintf("Total tests: %d\n", result.Total)))
 	if result.Fail == 0 {
-		strBuffer.WriteString(green("\nPASS\n"))
+		strBuffer.WriteString(green("\nPASS"))
 	} else {
-		strBuffer.WriteString(red("\nFAIL\n"))
+		strBuffer.WriteString(red("\nFAIL"))
 	}
 	return strBuffer.String()
 }


### PR DESCRIPTION
This fixes an issue where a test success from one config files would overwrite the failure of another config file, causing the entire test run to be reported as a success.

Also adds a few output modifications.

Fixes #146 