### PR TITLE
Strict unmarshalling for configs

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -179,7 +179,9 @@ func Parse(fp string) (types.StructureTest, error) {
 		return nil, errors.New("Unsupported schema version: " + version)
 	}
 
-	strictUnmarshal(testContents, st)
+	if err = strictUnmarshal(testContents, st); err != nil {
+		return nil, errors.New("error unmarshalling config: " + err.Error())
+	}
 
 	tests, _ := st.(types.StructureTest) //type assertion
 	tests.SetDriverImpl(driverImpl, *args)

--- a/pkg/types/v1/file_existence.go
+++ b/pkg/types/v1/file_existence.go
@@ -37,15 +37,17 @@ func (fe FileExistenceTest) MarshalYAML() (interface{}, error) {
 }
 
 func (fe *FileExistenceTest) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	type feAlias FileExistenceTest
-	feTest := feAlias{
+	// Create a type alias and call unmarshal on this type to unmarshal the yaml text into
+	// struct, since calling unmarshal on FileExistenceTest will result in an infinite loop.
+	type FileExistenceTestHolder FileExistenceTest
+	holder := FileExistenceTestHolder{
 		ShouldExist: true,
 	}
-	err := unmarshal(&feTest)
+	err := unmarshal(&holder)
 	if err != nil {
 		return err
 	}
-	*fe = FileExistenceTest(feTest)
+	*fe = FileExistenceTest(holder)
 	return nil
 }
 

--- a/pkg/types/v1/structure.go
+++ b/pkg/types/v1/structure.go
@@ -24,6 +24,7 @@ import (
 type StructureTest struct {
 	DriverImpl         func(drivers.DriverConfig) (drivers.Driver, error)
 	DriverArgs         drivers.DriverConfig
+	SchemaVersion      string              `yaml:"schemaVersion"`
 	GlobalEnvVars      []types.EnvVar      `yaml:"globalEnvVars"`
 	CommandTests       []CommandTest       `yaml:"commandTests"`
 	FileExistenceTests []FileExistenceTest `yaml:"fileExistenceTests"`

--- a/pkg/types/v2/file_existence.go
+++ b/pkg/types/v2/file_existence.go
@@ -38,17 +38,17 @@ func (fe FileExistenceTest) MarshalYAML() (interface{}, error) {
 }
 
 func (fe *FileExistenceTest) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// Create a type Alias and call unmarshal on this type to unmarshal the yaml text into
-	// struct. Else, calling unmarshal on FileExistence will result in to infinite recursive loop.
-	type feAlias FileExistenceTest
-	feTest := feAlias{
+	// Create a type alias and call unmarshal on this type to unmarshal the yaml text into
+	// struct, since calling unmarshal on FileExistenceTest will result in an infinite loop.
+	type FileExistenceTestHolder FileExistenceTest
+	holder := FileExistenceTestHolder{
 		ShouldExist: true,
 	}
-	err := unmarshal(&feTest)
+	err := unmarshal(&holder)
 	if err != nil {
 		return err
 	}
-	*fe = FileExistenceTest(feTest)
+	*fe = FileExistenceTest(holder)
 	return nil
 }
 

--- a/pkg/types/v2/structure.go
+++ b/pkg/types/v2/structure.go
@@ -25,6 +25,7 @@ import (
 type StructureTest struct {
 	DriverImpl         func(drivers.DriverConfig) (drivers.Driver, error)
 	DriverArgs         drivers.DriverConfig
+	SchemaVersion      string              `yaml:"schemaVersion"`
 	GlobalEnvVars      []types.EnvVar      `yaml:"globalEnvVars"`
 	CommandTests       []CommandTest       `yaml:"commandTests"`
 	FileExistenceTests []FileExistenceTest `yaml:"fileExistenceTests"`

--- a/tests/debian_failure_test.yaml
+++ b/tests/debian_failure_test.yaml
@@ -30,10 +30,3 @@ fileExistenceTests:
 licenseTests:
 - debian: true
   files:
-metadataTest:
-  env:
-  - key: "MISSING_VAR"
-    value: "MISSING_VAR_VALUE"
-  labels:
-  - key: "missing.label"
-    value: "missing_label_value"


### PR DESCRIPTION
Previously, we were using `yaml.UnmarshalStrict` to do the unmarshalling of the configs, but since we were ignoring the error, this was failing silently all over the place. With this change, configs are now strictly validated, and tests will fail to run if any parsing errors occur.

In order to do this, I needed to add the `SchemaVersion` to the top level struct so this could be parsed out correctly. Also, renamed a few things to make them more clear if they're surfaced to the user.

Should fix #146 