### PR TITLE
Fix tar-format image not being properly prepared.

### DIFF
--- a/pkg/drivers/tar_driver.go
+++ b/pkg/drivers/tar_driver.go
@@ -40,6 +40,7 @@ func NewTarDriver(args DriverConfig) (Driver, error) {
 		prepper = &pkgutil.TarPrepper{
 			Source: imageName,
 		}
+		image, err = prepper.GetImage()
 	} else {
 		// see if image exists locally first.
 		prepper = &pkgutil.DaemonPrepper{


### PR DESCRIPTION
This happens when the driver is `tar` and an tar file is passed as the
image.