### PR TITLE
Check files executable bit against a specified user group

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ directory should exist in the file system
   or directory.
 - Gid (`int`, *optional*): The expected Unix group ID that has access to the
   file or directory.
-- IsExecutableBy (`string`, *optional*): Name of group that file should be executable by.
+- IsExecutableBy (`string`, *optional*): Checks if file is executable by a given user.
   One of `owner`, `group`, `other` or `any`
 
 Example:

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ directory should exist in the file system
   or directory.
 - Gid (`int`, *optional*): The expected Unix group ID that has access to the
   file or directory.
+- IsExectuableBy (`string`, *optional*): Checks if file is executable by a given
+  user. One of `owner`, `group`, `other` or `any`
 
 Example:
 ```yaml
@@ -154,6 +156,7 @@ fileExistenceTests:
   permissions: '-rw-r--r--'
   uid: 1000
   gid: 1000
+  isExectuableBy: 'group'
 ```
 
 ## File Content Tests

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ directory should exist in the file system
   or directory.
 - Gid (`int`, *optional*): The expected Unix group ID that has access to the
   file or directory.
-- IsExectuableBy (`string`, *optional*): Checks if file is executable by a given
-  user. One of `owner`, `group`, `other` or `any`
+- IsExecutableBy (`string`, *optional*): Name of group that file should be executable by.
+  One of `owner`, `group`, `other` or `any`
 
 Example:
 ```yaml
@@ -156,7 +156,7 @@ fileExistenceTests:
   permissions: '-rw-r--r--'
   uid: 1000
   gid: 1000
-  isExectuableBy: 'group'
+  isExecutableBy: 'group'
 ```
 
 ## File Content Tests

--- a/pkg/types/v2/file_existence.go
+++ b/pkg/types/v2/file_existence.go
@@ -36,7 +36,7 @@ type FileExistenceTest struct {
 	Permissions    string `yaml:"permissions"`    // expected Unix permission string of the file, e.g. drwxrwxrwx
 	Uid            int    `yaml:"uid"`            // ID of the owner of the file
 	Gid            int    `yaml:"gid"`            // ID of the group of the file
-	IsExecutableBy string `yaml:"isExecutableBy"` // whether file should be executable
+	IsExecutableBy string `yaml:"isExecutableBy"` // name of group that file should be executable by
 }
 
 func (fe FileExistenceTest) MarshalYAML() (interface{}, error) {

--- a/tests/debian_test.yaml
+++ b/tests/debian_test.yaml
@@ -27,6 +27,9 @@ fileExistenceTests:
   shouldExist: true
   uid: 0
   gid: 0
+- name: 'Date'
+  path: '/bin/date'
+  isExecutableBy: 'owner'
 - name: 'Netbase'
   path: '/etc/protocols'
   shouldExist: true


### PR DESCRIPTION
Ref #63 

Adds an additional field to File Execution tests; `isExecutableBy`. This checks a given file (or folder) has executable permissions for a specified user type:
- `owner`
- `group`
- `other`
- `all` (Passes if _any_ executable bit is set)

Optional field that can be ommitted.

This follows similar convention to that of serverspec's `be_executable` assertion.