### PR TITLE
Log actual values in error message.

### DIFF
--- a/pkg/types/v2/command.go
+++ b/pkg/types/v2/command.go
@@ -107,25 +107,25 @@ func (ct *CommandTest) Run(driver drivers.Driver) *types.TestResult {
 func (ct *CommandTest) CheckOutput(result *types.TestResult, stdout string, stderr string, exitCode int) {
 	for _, errStr := range ct.ExpectedError {
 		if !utils.CompileAndRunRegex(errStr, stderr, true) {
-			result.Errorf("Expected string '%s' not found in error", errStr)
+			result.Errorf("Expected string '%s' not found in error '%s'", errStr, stderr)
 			result.Fail()
 		}
 	}
 	for _, errStr := range ct.ExcludedError {
 		if !utils.CompileAndRunRegex(errStr, stderr, false) {
-			result.Errorf("Excluded string '%s' found in error", errStr)
+			result.Errorf("Excluded string '%s' found in error '%s'", errStr, stderr)
 			result.Fail()
 		}
 	}
 	for _, outStr := range ct.ExpectedOutput {
 		if !utils.CompileAndRunRegex(outStr, stdout, true) {
-			result.Errorf("Expected string '%s' not found in output", outStr)
+			result.Errorf("Expected string '%s' not found in output '%s'", outStr, stdout)
 			result.Fail()
 		}
 	}
 	for _, outStr := range ct.ExcludedOutput {
 		if !utils.CompileAndRunRegex(outStr, stdout, false) {
-			result.Errorf("Excluded string '%s' found in output", outStr)
+			result.Errorf("Excluded string '%s' found in output '%s'", outStr, stdout)
 			result.Fail()
 		}
 	}

--- a/pkg/types/v2/metadata.go
+++ b/pkg/types/v2/metadata.go
@@ -120,7 +120,7 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 		} else if len(*mt.Cmd) > 0 {
 			for i := range *mt.Cmd {
 				if (*mt.Cmd)[i] != imageConfig.Cmd[i] {
-					result.Errorf("Image config Cmd does not match expected value: %s", *mt.Cmd)
+					result.Errorf("Image config Cmd %v does not match expected value: %s", imageConfig.Cmd, *mt.Cmd)
 					result.Fail()
 				}
 			}
@@ -134,7 +134,7 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 		} else {
 			for i := range *mt.Entrypoint {
 				if (*mt.Entrypoint)[i] != imageConfig.Entrypoint[i] {
-					result.Errorf("Image config entrypoint does not match expected value: %s", *mt.Entrypoint)
+					result.Errorf("Image config entrypoint %v does not match expected value: %s", imageConfig.Entrypoint, *mt.Entrypoint)
 					result.Fail()
 				}
 			}


### PR DESCRIPTION
Makes it quicker to spot what is actually incorrect in these tests.