### PR TITLE
Adds regex support for env/label metadata tests

### DIFF
--- a/pkg/drivers/host_driver.go
+++ b/pkg/drivers/host_driver.go
@@ -86,7 +86,7 @@ func (d *HostDriver) SetEnv(envVars []unversioned.EnvVar) error {
 func SetEnvVars(envVars []unversioned.EnvVar) []unversioned.EnvVar {
 	var originalVars []unversioned.EnvVar
 	for _, envVar := range envVars {
-		originalVars = append(originalVars, unversioned.EnvVar{envVar.Key, os.Getenv(envVar.Key)})
+		originalVars = append(originalVars, unversioned.EnvVar{envVar.Key, os.Getenv(envVar.Key), envVar.IsRegex})
 		if err := os.Setenv(envVar.Key, os.ExpandEnv(envVar.Value)); err != nil {
 			ctc_lib.Log.Errorf("Error setting env var: %s", err)
 		}

--- a/pkg/types/unversioned/types.go
+++ b/pkg/types/unversioned/types.go
@@ -20,13 +20,15 @@ import (
 )
 
 type EnvVar struct {
-	Key   string
-	Value string
+	Key     string
+	Value   string
+	IsRegex bool `yaml:"isRegex"`
 }
 
 type Label struct {
-	Key   string
-	Value string
+	Key     string
+	Value   string
+	IsRegex bool `yaml:"isRegex"`
 }
 
 type Config struct {

--- a/pkg/types/v2/metadata.go
+++ b/pkg/types/v2/metadata.go
@@ -91,7 +91,7 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 
 	for _, pair := range mt.Env {
 		if val, ok := imageConfig.Env[pair.Key]; ok {
-			match := false
+			var match bool
 			if pair.IsRegex {
 				match = utils.CompileAndRunRegex(pair.Value, val, true)
 			} else {
@@ -109,7 +109,7 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 
 	for _, pair := range mt.Labels {
 		if val, ok := imageConfig.Labels[pair.Key]; ok {
-			match := false
+			var match bool
 			if pair.IsRegex {
 				match = utils.CompileAndRunRegex(pair.Value, val, true)
 			} else {

--- a/pkg/types/v2/metadata.go
+++ b/pkg/types/v2/metadata.go
@@ -91,7 +91,13 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 
 	for _, pair := range mt.Env {
 		if val, ok := imageConfig.Env[pair.Key]; ok {
-			if pair.Value != val {
+			match := false
+			if pair.IsRegex {
+				match = utils.CompileAndRunRegex(pair.Value, val, true)
+			} else {
+				match = (pair.Value == val)
+			}
+			if !match {
 				result.Errorf("env var %s value %s does not match expected value: %s", pair.Key, val, pair.Value)
 				result.Fail()
 			}
@@ -103,7 +109,13 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 
 	for _, pair := range mt.Labels {
 		if val, ok := imageConfig.Labels[pair.Key]; ok {
-			if pair.Value != val {
+			match := false
+			if pair.IsRegex {
+				match = utils.CompileAndRunRegex(pair.Value, val, true)
+			} else {
+				match = (pair.Value == val)
+			}
+			if !match {
 				result.Errorf("label %s value %s does not match expected value: %s", pair.Key, val, pair.Value)
 				result.Fail()
 			}

--- a/tests/Dockerfile.metadata
+++ b/tests/Dockerfile.metadata
@@ -2,7 +2,8 @@ FROM gcr.io/google-appengine/debian8:latest
 
 ENV SOME_KEY="SOME_VAL" \
     EMPTY_VAR="" \
-    FOO_BAR="FOO\:BAR"
+    FOO_BAR="FOO\:BAR" \
+    REGEX_VAR="test-2.1.8"
 
 LABEL localnet.localdomain.commit_hash="0123456789abcdef0123456789abcdef01234567" \
       localnet.my-domain.my-label="my test label" \

--- a/tests/debian_metadata_test.yaml
+++ b/tests/debian_metadata_test.yaml
@@ -7,8 +7,14 @@ metadataTest:
     value: ''
   - key: 'FOO_BAR'
     value: 'FOO\:BAR'
+  - key: 'REGEX_VAR'
+    value: '[a-z]+-2\.1\.*'
+    isRegex: true
   labels:
   - key: 'localnet.localdomain.commit_hash'
     value: '0123456789abcdef0123456789abcdef01234567'
+  - key: 'localnet.my-domain.my-label'
+    value: 'my .+ label'
+    isRegex: true
   - key: 'label-with-empty-val'
     value: ''


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/container-structure-test/issues/145

As mentioned in the above issue, this feature was removed in PR https://github.com/GoogleContainerTools/container-structure-test/pull/137. This is an attempt to add the feature back while supporting cases where regex is not desired. It will be off by default and can be used by specifying an optional `isRegex` flag for each key/value pair.