### PR TITLE
Fix characters escaping in expectedContents expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Example:
 fileContentTests:
 - name: 'Debian Sources'
   path: '/etc/apt/sources.list'
-  expectedContents: ['.*httpredir\\.debian\\.org.*']
+  expectedContents: ['.*httpredir\.debian\.org.*']
   excludedContents: ['.*gce_debian_mirror.*']
 ```
 


### PR DESCRIPTION
In fileContentTests documentation, the expectedContents example contains double backslash but it seems it only needs one.