### PR TITLE
Fix broken host driver, add tests for tar and host drivers

### DIFF
--- a/cmd/container-structure-test/app/cmd/test.go
+++ b/cmd/container-structure-test/app/cmd/test.go
@@ -151,7 +151,6 @@ func runTests(out io.Writer, channel chan interface{}, args *drivers.DriverConfi
 
 func AddTestFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&opts.ImagePath, "image", "i", "", "path to test image")
-	cmd.MarkFlagRequired("image")
 	cmd.Flags().StringVarP(&opts.Driver, "driver", "d", "docker", "driver to use when running tests")
 	cmd.Flags().StringVar(&opts.Metadata, "metadata", "", "path to image metadata file")
 

--- a/pkg/drivers/host_driver.go
+++ b/pkg/drivers/host_driver.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 
 	"github.com/GoogleContainerTools/container-structure-test/pkg/types/unversioned"
+	"github.com/google/go-containerregistry/pkg/v1"
 )
 
 type HostDriver struct {
@@ -156,13 +157,13 @@ func (d *HostDriver) GetConfig() (unversioned.Config, error) {
 		return unversioned.Config{}, errors.Wrap(err, "Error retrieving config")
 	}
 
-	var metadata unversioned.FlattenedMetadata
+	var metadata v1.ConfigFile
 
 	json.Unmarshal(file, &metadata)
 	config := metadata.Config
 
-	// // docker provides these as maps (since they can be mapped in docker run commands)
-	// // since this will never be the case when built through a dockerfile, we convert to list of strings
+	// docker provides these as maps (since they can be mapped in docker run commands)
+	// since this will never be the case when built through a dockerfile, we convert to list of strings
 	volumes := []string{}
 	for v := range config.Volumes {
 		volumes = append(volumes, v)
@@ -179,8 +180,8 @@ func (d *HostDriver) GetConfig() (unversioned.Config, error) {
 		Entrypoint:   config.Entrypoint,
 		Cmd:          config.Cmd,
 		Volumes:      volumes,
-		Workdir:      config.Workdir,
+		Workdir:      config.WorkingDir,
 		ExposedPorts: ports,
-		Labels:       convertSliceToMap(config.Labels),
+		Labels:       config.Labels,
 	}, nil
 }

--- a/pkg/types/unversioned/types.go
+++ b/pkg/types/unversioned/types.go
@@ -41,20 +41,6 @@ type Config struct {
 	Labels       map[string]string
 }
 
-type FlattenedConfig struct {
-	Env          []string            `json:"Env"`
-	Entrypoint   []string            `json:"Entrypoint"`
-	Cmd          []string            `json:"Cmd"`
-	Volumes      map[string]string   `json:"Volumes"`
-	Workdir      string              `json:"WorkingDir"`
-	ExposedPorts map[string][]string `json:"ExposedPorts"`
-	Labels       []string            `json:"Labels"`
-}
-
-type FlattenedMetadata struct {
-	Config FlattenedConfig `json:"config"`
-}
-
 type TestResult struct {
 	Name   string
 	Pass   bool


### PR DESCRIPTION
The host driver is very useful for validating image metadata in the case
where docker daemon is not available and producing a fat tarball with
"docker save" would be too costly.  The host driver should allow us to
implement very fast metadata tests for bazel-built containers.

The host driver was broken, because --image command line flag had been
marked required even though host driver uses the --metadata flag (and
rejects the --image flag).

Add end-to-end test coverage for the tar and host drivers.