### PR TITLE
Allow to specify docker runtime to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,9 @@ container-structure-test test --driver tar --image gcr.io/registry/image:latest 
 
 The currently supported drivers in the framework are:
 - `docker`: the default driver.
-Supports all tests, and uses the Docker daemon on the host to run them.
+Supports all tests, and uses the Docker daemon on the host to run them. You can
+set the runtime to use (by example `runsc` to run with gVisor) using `--runtime`
+flag.
 - `tar`: a tar driver, which extracts an image filesystem to wherever tests are
 running, and runs file/metadata tests against it.
 Does *not* support command tests.

--- a/cmd/container-structure-test/app/cmd/test.go
+++ b/cmd/container-structure-test/app/cmd/test.go
@@ -89,6 +89,7 @@ func run(out io.Writer) error {
 		Image:    opts.ImagePath,
 		Save:     opts.Save,
 		Metadata: opts.Metadata,
+		Runtime:  opts.Runtime,
 	}
 
 	var err error
@@ -179,6 +180,7 @@ func AddTestFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&opts.ImagePath, "image", "i", "", "path to test image")
 	cmd.Flags().StringVarP(&opts.Driver, "driver", "d", "docker", "driver to use when running tests")
 	cmd.Flags().StringVar(&opts.Metadata, "metadata", "", "path to image metadata file")
+	cmd.Flags().StringVar(&opts.Runtime, "runtime", "", "runtime to use with docker driver")
 
 	cmd.Flags().BoolVar(&opts.Pull, "pull", false, "force a pull of the image before running tests")
 	cmd.Flags().BoolVar(&opts.Save, "save", false, "preserve created containers after test run")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -17,6 +17,7 @@ package config
 type StructureTestOptions struct {
 	ImagePath   string
 	Driver      string
+	Runtime     string
 	Metadata    string
 	TestReport  string
 	ConfigFiles []string

--- a/pkg/drivers/docker_driver.go
+++ b/pkg/drivers/docker_driver.go
@@ -40,6 +40,7 @@ type DockerDriver struct {
 	cli           docker.Client
 	env           map[string]string
 	save          bool
+	runtime       string
 }
 
 func NewDockerDriver(args DriverConfig) (Driver, error) {
@@ -53,7 +54,17 @@ func NewDockerDriver(args DriverConfig) (Driver, error) {
 		cli:           *newCli,
 		env:           nil,
 		save:          args.Save,
+		runtime:       args.Runtime,
 	}, nil
+}
+
+func (d *DockerDriver) hostConfig() *docker.HostConfig {
+	if d.runtime != "" {
+		return &docker.HostConfig{
+			Runtime: d.runtime,
+		}
+	}
+	return nil
 }
 
 func (d *DockerDriver) Destroy() {
@@ -77,7 +88,7 @@ func (d *DockerDriver) SetEnv(envVars []unversioned.EnvVar) error {
 			AttachStdout: true,
 			AttachStderr: true,
 		},
-		HostConfig:       nil,
+		HostConfig:       d.hostConfig(),
 		NetworkingConfig: nil,
 	})
 	if err != nil {
@@ -180,7 +191,7 @@ func (d *DockerDriver) retrieveTar(path string) (*tar.Reader, error) {
 			Image: d.currentImage,
 			Cmd:   []string{utils.NoopCommand},
 		},
-		HostConfig:       nil,
+		HostConfig:       d.hostConfig(),
 		NetworkingConfig: nil,
 	})
 	if err != nil {
@@ -295,7 +306,7 @@ func (d *DockerDriver) runAndCommit(env []string, command []string) (string, err
 			AttachStdout: true,
 			AttachStderr: true,
 		},
-		HostConfig:       nil,
+		HostConfig:       d.hostConfig(),
 		NetworkingConfig: nil,
 	})
 	if err != nil {
@@ -341,7 +352,7 @@ func (d *DockerDriver) exec(env []string, command []string) (string, string, int
 			AttachStdout: true,
 			AttachStderr: true,
 		},
-		HostConfig:       nil,
+		HostConfig:       d.hostConfig(),
 		NetworkingConfig: nil,
 	})
 	if err != nil {

--- a/pkg/drivers/driver.go
+++ b/pkg/drivers/driver.go
@@ -32,6 +32,7 @@ type DriverConfig struct {
 	Image    string // used by Docker/Tar drivers
 	Save     bool   // used by Docker/Tar drivers
 	Metadata string // used by Host driver
+	Runtime  string // used by Docker driver
 }
 
 type Driver interface {


### PR DESCRIPTION
By default no specific runtime is selected.
It allows to select `runsc` to run using gVisor if present.

```shell
container-structure-test test \
  --driver docker --runtime runsc \
  --image gcr.io/registry/image:latest \
  --config config.yaml
```