### PR TITLE
Add test duration

### DIFF
--- a/cmd/container-structure-test/app/cmd/test/util.go
+++ b/cmd/container-structure-test/app/cmd/test/util.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"io/ioutil"
 	"strings"
+	"time"
 
 	"github.com/GoogleContainerTools/container-structure-test/pkg/config"
 	"github.com/GoogleContainerTools/container-structure-test/pkg/drivers"
@@ -107,6 +108,7 @@ func Parse(fp string, args *drivers.DriverConfig, driverImpl func(drivers.Driver
 func ProcessResults(out io.Writer, json bool, c chan interface{}) error {
 	totalPass := 0
 	totalFail := 0
+	totalDuration := time.Duration(0)
 	errStrings := make([]string, 0)
 	results, err := channelToSlice(c)
 	if err != nil {
@@ -122,6 +124,7 @@ func ProcessResults(out io.Writer, json bool, c chan interface{}) error {
 		} else {
 			totalFail++
 		}
+		totalDuration += r.Duration
 	}
 	if totalPass+totalFail == 0 || totalFail > 0 {
 		errStrings = append(errStrings, "FAIL")
@@ -131,9 +134,10 @@ func ProcessResults(out io.Writer, json bool, c chan interface{}) error {
 	}
 
 	summary := unversioned.SummaryObject{
-		Total: totalFail + totalPass,
-		Pass:  totalPass,
-		Fail:  totalFail,
+		Total:    totalFail + totalPass,
+		Pass:     totalPass,
+		Fail:     totalFail,
+		Duration: totalDuration,
 	}
 	if json {
 		// only output results here if we're in json mode

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -36,6 +36,7 @@ func OutputResult(out io.Writer, result *types.TestResult) {
 	} else {
 		color.Red.Fprintln(out, "--- FAIL")
 	}
+	color.Default.Fprintf(out, "duration: %s\n", result.Duration.String())
 	if result.Stdout != "" {
 		color.Blue.Fprintf(out, "stdout: %s\n", result.Stdout)
 	}
@@ -78,6 +79,7 @@ func FinalResults(out io.Writer, jsonOut bool, result types.SummaryObject) error
 	color.Default.Fprintln(out, strings.Repeat("=", bannerLength))
 	color.LightGreen.Fprintf(out, "Passes:      %d\n", result.Pass)
 	color.LightRed.Fprintf(out, "Failures:    %d\n", result.Fail)
+	color.Default.Fprintf(out, "Duration:    %s\n", result.Duration.String())
 	color.Cyan.Fprintf(out, "Total tests: %d\n", result.Total)
 	color.Default.Fprintln(out, "")
 	if result.Fail == 0 {

--- a/pkg/types/unversioned/types.go
+++ b/pkg/types/unversioned/types.go
@@ -17,6 +17,7 @@ package unversioned
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 type EnvVar struct {
@@ -42,11 +43,12 @@ type Config struct {
 }
 
 type TestResult struct {
-	Name   string
-	Pass   bool
-	Stdout string   `json:",omitempty"`
-	Stderr string   `json:",omitempty"`
-	Errors []string `json:",omitempty"`
+	Name     string
+	Pass     bool
+	Stdout   string   `json:",omitempty"`
+	Stderr   string   `json:",omitempty"`
+	Errors   []string `json:",omitempty"`
+	Duration time.Duration
 }
 
 func (t *TestResult) String() string {
@@ -63,6 +65,7 @@ func (t *TestResult) String() string {
 		strRepr += fmt.Sprintf("\nStderr:%s", t.Stderr)
 	}
 	strRepr += fmt.Sprintf("\nErrors:%s\n", strings.Join(t.Errors, ","))
+	strRepr += fmt.Sprintf("\nDuration:%s\n", t.Duration.String())
 	return strRepr
 }
 
@@ -83,8 +86,9 @@ func (t *TestResult) IsPass() bool {
 }
 
 type SummaryObject struct {
-	Pass    int
-	Fail    int
-	Total   int
-	Results []*TestResult `json:",omitempty"`
+	Pass     int
+	Fail     int
+	Total    int
+	Duration time.Duration
+	Results  []*TestResult `json:",omitempty"`
 }

--- a/pkg/types/v1/command.go
+++ b/pkg/types/v1/command.go
@@ -16,6 +16,7 @@ package v1
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/sirupsen/logrus"
 

--- a/pkg/types/v1/command.go
+++ b/pkg/types/v1/command.go
@@ -74,13 +74,17 @@ func (ct *CommandTest) Run(driver drivers.Driver) *types.TestResult {
 	if err != nil {
 		logrus.Errorf("error retrieving image config: %s", err.Error())
 	}
+	start := time.Now()
 	stdout, stderr, exitcode, err := driver.ProcessCommand(ct.EnvVars, utils.SubstituteEnvVars(ct.Command, config.Env))
+	end := time.Now()
+	duration := end.Sub(start)
 	result := &types.TestResult{
-		Name:   ct.LogName(),
-		Pass:   true,
-		Errors: make([]string, 0),
-		Stderr: stderr,
-		Stdout: stdout,
+		Name:     ct.LogName(),
+		Pass:     true,
+		Errors:   make([]string, 0),
+		Stderr:   stderr,
+		Stdout:   stdout,
+		Duration: duration,
 	}
 	if err != nil {
 		result.Fail()

--- a/pkg/types/v2/command.go
+++ b/pkg/types/v2/command.go
@@ -16,6 +16,7 @@ package v2
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -86,13 +87,17 @@ func (ct *CommandTest) Run(driver drivers.Driver) *types.TestResult {
 		logrus.Errorf("error retrieving image config: %s", err.Error())
 	}
 	fullCommand := utils.SubstituteEnvVars(append([]string{ct.Command}, ct.Args...), config.Env)
+	start := time.Now()
 	stdout, stderr, exitcode, err := driver.ProcessCommand(ct.EnvVars, fullCommand)
+	end := time.Now()
+	duration := end.Sub(start)
 	result := &types.TestResult{
-		Name:   ct.LogName(),
-		Pass:   true,
-		Errors: make([]string, 0),
-		Stderr: stderr,
-		Stdout: stdout,
+		Name:     ct.LogName(),
+		Pass:     true,
+		Errors:   make([]string, 0),
+		Stderr:   stderr,
+		Stdout:   stdout,
+		Duration: duration,
 	}
 	if err != nil {
 		result.Fail()


### PR DESCRIPTION
Hi 👋 

First of all, thanks for your work!
I love *container-structure-test* 😄 

This PR adds a `Duration` field in `TestResult` as well as `SummaryObject` so we can measure each test duration and print a total duration in the report.

Fixes #139 