### PR TITLE
Add unexposedPorts and unmountedVolumes to metadata tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ container.
 - Entrypoint (`[]string`): The entrypoint of the container
 - Cmd (`[]string`): The CMD specified in the container.
 - Exposed Ports (`[]string`): The ports exposed in the container.
+- Unexposed Ports (`[]string`): The ports **NOT** exposed in the container.
 - Volumes (`[]string`): The volumes exposed in the container.
+- UnmountedVolumes (`[]string`): The volumes **NOT** exposed in the container.
 - Workdir (`string`): The default working directory of the container.
 
 Example:

--- a/tests/debian_metadata_test.yaml
+++ b/tests/debian_metadata_test.yaml
@@ -18,3 +18,5 @@ metadataTest:
     isRegex: true
   - key: 'label-with-empty-val'
     value: ''
+  unexposedPorts: ['80']
+  unmountedVolumes: ['/root']


### PR DESCRIPTION
This PR adds support for `unexposedPorts` and `unmountedVolumes` to `metadataTests` as specified in #171.
Metadata tests and documentation have been updated accordingly.