### PR TITLE
file existence test docs: replace access by owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,9 @@ are checked. These tests can also be used to ensure a file or directory is
 directory should exist in the file system
 - Permissions (`string`, *optional*): The expected Unix permission string (e.g.
   drwxrwxrwx) of the files or directory.
-- Uid (`int`, *optional*): The expected Unix user ID that has access to the file
+- Uid (`int`, *optional*): The expected Unix user ID of the owner of the file
   or directory.
-- Gid (`int`, *optional*): The expected Unix group ID that has access to the
-  file or directory.
+- Gid (`int`, *optional*): The expected Unix group ID of the owner of the file or directory.
 - IsExecutableBy (`string`, *optional*): Checks if file is executable by a given user.
   One of `owner`, `group`, `other` or `any`
 


### PR DESCRIPTION
Referring the code:

```
type FileExistenceTest struct {
	Name           string `yaml:"name"`           // name of test
	Path           string `yaml:"path"`           // file to check existence of
	ShouldExist    bool   `yaml:"shouldExist"`    // whether or not the file should exist
	Permissions    string `yaml:"permissions"`    // expected Unix permission string of the file, e.g. drwxrwxrwx
	Uid            int    `yaml:"uid"`            // ID of the owner of the file
	Gid            int    `yaml:"gid"`            // ID of the group of the file
	IsExecutableBy string `yaml:"isExecutableBy"` // name of group that file should be executable by
}
```

I think the proposed change is more accurate