### PR TITLE
[FIX] SchemaVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ as normal.
 
 #### Supported Fields:
 
-**NOTE: `schemaVersion` must be specified in all container-structure-test yamls. The current version is `v2.0.0`.**
+**NOTE: `schemaVersion` must be specified in all container-structure-test yamls. The current version is `2.0.0`.**
 
 - Name (`string`, **required**): The name of the test
 - Setup (`[][]string`, *optional*): A list of commands


### PR DESCRIPTION
Hi everyone 👋 

As explained here: https://github.com/GoogleContainerTools/container-structure-test/issues/212. 

The `schemaVersion` can't be `v2.0.0` but need to be `2.0.0` in order to parse the file.

Thanks for the feedback 🙂 