### PR TITLE
Don’t check properties of a file that doesn’t exist

### DIFF
--- a/pkg/types/v2/file_existence.go
+++ b/pkg/types/v2/file_existence.go
@@ -105,6 +105,12 @@ func (ft FileExistenceTest) Run(driver drivers.Driver) *types.TestResult {
 		result.Errorf("File %s should not exist but does", ft.Path)
 		result.Fail()
 	}
+
+	// Next assertions don't make sense if the file doesn't exist.
+	if !ft.ShouldExist {
+		return result
+	}
+
 	if ft.Permissions != "" && info != nil {
 		perms := info.Mode()
 		if perms.String() != ft.Permissions {


### PR DESCRIPTION
Fixes #242

Signed-off-by: David Gageot <david@gageot.net>