### PR TITLE
Fix the error message when schema version is missing

### DIFF
--- a/cmd/container-structure-test/app/cmd/test/util.go
+++ b/cmd/container-structure-test/app/cmd/test/util.go
@@ -86,7 +86,7 @@ func Parse(fp string, args *drivers.DriverConfig, driverImpl func(drivers.Driver
 
 	version := versionHolder.SchemaVersion
 	if version == "" {
-		return nil, errors.New("Please provide JSON schema version")
+		return nil, errors.New("Please provide schema version")
 	}
 
 	var st types.StructureTest


### PR DESCRIPTION
Since both JSON and YAML are supported, mentioning only JSON is really confusing.