### PR TITLE
Produce linux/arm64 binaries for use in container_test

### DIFF
--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -4,9 +4,15 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 'builder', '-f', 'deploy/Dockerfile.build', '.']
 
-# Do the go build
-  - name: 'builder'
+# Do the go build for amd64
+  - name: 'builder-amd64'
     args: ['make', 'cross']
+    env: ['GOARCH=amd64']
+
+# Do the go build for arm64
+  - name: 'builder-arm64'
+    args: ['make', 'cross']
+    env: ['GOARCH=arm64']
 
 # Upload to GCS
   - name: 'gcr.io/cloud-builders/gsutil'

--- a/deploy/release_cloudbuild.yaml
+++ b/deploy/release_cloudbuild.yaml
@@ -5,9 +5,15 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 'builder', '-f', 'deploy/Dockerfile.build', '.']
 
-# Do the go build
-  - name: 'builder'
+# Do the go build for amd64
+  - name: 'builder-amd64'
     args: ['make', 'cross']
+    env: ['GOARCH=amd64']
+
+# Do the go build for arm64
+  - name: 'builder-arm64'
+    args: ['make', 'cross']
+    env: ['GOARCH=arm64']
 
 # Upload to GCS
   - name: 'gcr.io/cloud-builders/gsutil'


### PR DESCRIPTION
cc @dlorenc 

I was able to produce `arm64` binaries on my ubuntu VM with `GOARCH=arm64 make cross`