### PR TITLE
Produce linux/s390x and linux/ppc64le binaries to use in container_test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ dist: trusty
 arch:
   - amd64
   - arm64
+  - s390x
+  - ppc64le
 
 language: go
 go:

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -14,6 +14,17 @@ steps:
     args: ['make', 'cross']
     env: ['GOARCH=arm64']
 
+# Do the go build for s390x
+  - name: 'builder'
+    args: ['make', 'cross']
+    env: ['GOARCH=s390x']
+
+# Do the go build for ppc64le
+  - name: 'builder'
+    args: ['make', 'cross']
+    env: ['GOARCH=ppc64le']
+
+
 # Upload to GCS
   - name: 'gcr.io/cloud-builders/gsutil'
     args: ['cp', '-r', 'out/*', 'gs://container-structure-test/builds/$COMMIT_SHA/']

--- a/deploy/release_cloudbuild.yaml
+++ b/deploy/release_cloudbuild.yaml
@@ -15,6 +15,16 @@ steps:
     args: ['make', 'cross']
     env: ['GOARCH=arm64']
 
+# Do the go build for s390x
+  - name: 'builder'
+    args: ['make', 'cross']
+    env: ['GOARCH=s390x']
+
+# Do the go build for s390x
+  - name: 'builder'
+    args: ['make', 'cross']
+    env: ['GOARCH=ppc64le']
+
 # Upload to GCS
   - name: 'gcr.io/cloud-builders/gsutil'
     args: ['cp', '-r', 'out/*', 'gs://container-structure-test/$TAG_NAME/']

--- a/tests/ppc64le/ubuntu_20_04_failure_test.yaml
+++ b/tests/ppc64le/ubuntu_20_04_failure_test.yaml
@@ -1,0 +1,32 @@
+schemaVersion: '1.0.0'
+commandTests:
+- name: 'bad apt-get-command'
+  command: ['apt-get', 'dslkfjasl']
+  excludedError: ['.*FAIL.*']
+  expectedOutput: ['.*Usage.*']
+- name: 'apt-config'
+  command: ['apt-config', 'dump']
+  expectedOutput: ['Acquire::Retries "3"']
+  name: 'apt-config'
+- name: 'path'
+  command: ['sh', '-c', 'echo $PATH']
+  expectedOutput: ['/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin']
+fileContentTests:
+- name: 'Debian Sources'
+  excludedContents: ['.*gce_debian_mirror.*']
+  expectedContents: ['.*httpredir\.debian\.org.*']
+  path: '/etc/apt/sources.list'
+- name: 'Wrong Retry Policy'
+  expectedContents: ['Acquire::Retries 4;']
+  path: '/etc/apt/apt.conf.d/apt-retry'
+fileExistenceTests:
+- name: 'Fake Dir'
+  path: '/foo/bar'
+  shouldExist: true
+- name: 'Wrong permissions'
+  path: '/etc/apt/sources.list'
+  permissions: '-rwxrwxrwx'
+  shouldExist: true
+licenseTests:
+- debian: true
+  files:

--- a/tests/ppc64le/ubuntu_20_04_metadata_test.yaml
+++ b/tests/ppc64le/ubuntu_20_04_metadata_test.yaml
@@ -1,0 +1,22 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+metadataTest:
+  env:
+  - key: 'SOME_KEY'
+    value: 'SOME_VAL'
+  - key: 'EMPTY_VAR'
+    value: ''
+  - key: 'FOO_BAR'
+    value: 'FOO\:BAR=BAZ'
+  - key: 'REGEX_VAR'
+    value: '[a-z]+-2\.1\.*'
+    isRegex: true
+  labels:
+  - key: 'localnet.localdomain.commit_hash'
+    value: '0123456789abcdef0123456789abcdef01234567'
+  - key: 'localnet.my-domain.my-label'
+    value: 'my .+ label'
+    isRegex: true
+  - key: 'label-with-empty-val'
+    value: ''
+  unexposedPorts: ['80']
+  unmountedVolumes: ['/root']

--- a/tests/ppc64le/ubuntu_20_04_test.yaml
+++ b/tests/ppc64le/ubuntu_20_04_test.yaml
@@ -1,0 +1,45 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+commandTests:
+- name: 'apt-get'
+  command: 'apt-get'
+  args: ['help']
+  excludedError: ['.*FAIL.*']
+  expectedOutput: ['.*Usage.*']
+- name: 'apt-config'
+  command: 'apt-config'
+  args: ['dump']
+  expectedOutput: ['APT::AutoRemove']
+- name: 'path'
+  command: 'sh'
+  args: ['-c', 'echo $PATH']
+  expectedOutput: ['/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin']
+fileContentTests:
+- name: 'Debian Sources'
+  excludedContents: ['.*gce_debian_mirror.*']
+  expectedContents: ['.*ports\.ubuntu\.com.*']
+  path: '/etc/apt/sources.list'
+- name: 'Passwd file'
+  expectedContents: ['root:x:0:0:root:/root:/bin/bash']
+  path: '/etc/passwd'
+fileExistenceTests:
+- name: 'Root'
+  path: '/'
+  shouldExist: true
+  uid: 0
+  gid: 0
+- name: 'Date'
+  path: '/bin/date'
+  isExecutableBy: 'owner'
+- name: 'Hosts File'
+  path: '/etc/hosts'
+  shouldExist: true
+- name: 'Machine ID'
+  path: '/etc/machine-id'
+- name: 'Dummy File'
+  path: '/etc/dummy'
+  shouldExist: false
+licenseTests:
+- debian: false
+  files:
+    - "/usr/share/doc/ubuntu-keyring/copyright"
+    - "/usr/share/doc/dash/copyright"

--- a/tests/s390x/ubuntu_20_04_failure_test.yaml
+++ b/tests/s390x/ubuntu_20_04_failure_test.yaml
@@ -1,0 +1,32 @@
+schemaVersion: '1.0.0'
+commandTests:
+- name: 'bad apt-get-command'
+  command: ['apt-get', 'dslkfjasl']
+  excludedError: ['.*FAIL.*']
+  expectedOutput: ['.*Usage.*']
+- name: 'apt-config'
+  command: ['apt-config', 'dump']
+  expectedOutput: ['Acquire::Retries "3"']
+  name: 'apt-config'
+- name: 'path'
+  command: ['sh', '-c', 'echo $PATH']
+  expectedOutput: ['/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin']
+fileContentTests:
+- name: 'Debian Sources'
+  excludedContents: ['.*gce_debian_mirror.*']
+  expectedContents: ['.*httpredir\.debian\.org.*']
+  path: '/etc/apt/sources.list'
+- name: 'Wrong Retry Policy'
+  expectedContents: ['Acquire::Retries 4;']
+  path: '/etc/apt/apt.conf.d/apt-retry'
+fileExistenceTests:
+- name: 'Fake Dir'
+  path: '/foo/bar'
+  shouldExist: true
+- name: 'Wrong permissions'
+  path: '/etc/apt/sources.list'
+  permissions: '-rwxrwxrwx'
+  shouldExist: true
+licenseTests:
+- debian: true
+  files:

--- a/tests/s390x/ubuntu_20_04_metadata_test.yaml
+++ b/tests/s390x/ubuntu_20_04_metadata_test.yaml
@@ -1,0 +1,22 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+metadataTest:
+  env:
+  - key: 'SOME_KEY'
+    value: 'SOME_VAL'
+  - key: 'EMPTY_VAR'
+    value: ''
+  - key: 'FOO_BAR'
+    value: 'FOO\:BAR=BAZ'
+  - key: 'REGEX_VAR'
+    value: '[a-z]+-2\.1\.*'
+    isRegex: true
+  labels:
+  - key: 'localnet.localdomain.commit_hash'
+    value: '0123456789abcdef0123456789abcdef01234567'
+  - key: 'localnet.my-domain.my-label'
+    value: 'my .+ label'
+    isRegex: true
+  - key: 'label-with-empty-val'
+    value: ''
+  unexposedPorts: ['80']
+  unmountedVolumes: ['/root']

--- a/tests/s390x/ubuntu_20_04_test.yaml
+++ b/tests/s390x/ubuntu_20_04_test.yaml
@@ -1,0 +1,45 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+commandTests:
+- name: 'apt-get'
+  command: 'apt-get'
+  args: ['help']
+  excludedError: ['.*FAIL.*']
+  expectedOutput: ['.*Usage.*']
+- name: 'apt-config'
+  command: 'apt-config'
+  args: ['dump']
+  expectedOutput: ['APT::AutoRemove']
+- name: 'path'
+  command: 'sh'
+  args: ['-c', 'echo $PATH']
+  expectedOutput: ['/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin']
+fileContentTests:
+- name: 'Debian Sources'
+  excludedContents: ['.*gce_debian_mirror.*']
+  expectedContents: ['.*ports\.ubuntu\.com.*']
+  path: '/etc/apt/sources.list'
+- name: 'Passwd file'
+  expectedContents: ['root:x:0:0:root:/root:/bin/bash']
+  path: '/etc/passwd'
+fileExistenceTests:
+- name: 'Root'
+  path: '/'
+  shouldExist: true
+  uid: 0
+  gid: 0
+- name: 'Date'
+  path: '/bin/date'
+  isExecutableBy: 'owner'
+- name: 'Hosts File'
+  path: '/etc/hosts'
+  shouldExist: true
+- name: 'Machine ID'
+  path: '/etc/machine-id'
+- name: 'Dummy File'
+  path: '/etc/dummy'
+  shouldExist: false
+licenseTests:
+- debian: false
+  files:
+    - "/usr/share/doc/ubuntu-keyring/copyright"
+    - "/usr/share/doc/dash/copyright"


### PR DESCRIPTION
The binary can be cross-compiled for s390x and ppc64le. All tests in Travis are passed.
Similar to what @mattmoor is done for arm64 -> https://github.com/GoogleContainerTools/container-structure-test/pull/266