### PR TITLE
Add support for the "user" metadata. Related to #80.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ container. isRegex (*optional*) interpretes the value as regex.
 - Volumes (`[]string`): The volumes exposed in the container.
 - UnmountedVolumes (`[]string`): The volumes **NOT** exposed in the container.
 - Workdir (`string`): The default working directory of the container.
+- User (`user`): The default user of the container.
 
 Example:
 ```yaml
@@ -234,6 +235,7 @@ metadataTest:
   entrypoint: []
   cmd: ["/bin/bash"]
   workdir: "/app"
+  user: "luke"
 ```
 
 ## License Tests
@@ -297,12 +299,12 @@ Container images can be represented in multiple formats, and the Docker image
 is just one of them. At their core, images are just a series of layers, each
 of which is a tarball, and so can be interacted with without a working Docker
 daemon. While running command tests currently requires a functioning Docker
-daemon on the host machine, File Existence/Content tests do not. This can be 
+daemon on the host machine, File Existence/Content tests do not. This can be
 useful when dealing with images which have been `docker export`ed
 or saved in a different image format than the Docker format, or when you're simply
 trying to run structure tests in an environment where Docker can't be installed.
 
-To run tests without using a Docker daemon, users can specify a different 
+To run tests without using a Docker daemon, users can specify a different
 "driver" to use in the tests, with the `--driver` flag.
 
 An example test run with a different driver looks like:
@@ -395,12 +397,12 @@ container_test(
       --runtime string       runtime to use with docker driver
       --save                 preserve created containers after test run
       --test-report string   generate test report and write it to specified file (supported format: json, junit; default: json)
- ```   
+ ```
 See this [example repo](https://github.com/nkubala/structure-test-examples) for a full working example.
 
 ## Output formats
 
-Reports are generated using one of the following output formats: `text`, `json` or `junit`.  
+Reports are generated using one of the following output formats: `text`, `json` or `junit`.
 Formats like `json` and `junit` can also be used to write a report to a specified file using the `--test-report`.
 
 ### Output samples

--- a/pkg/drivers/docker_driver.go
+++ b/pkg/drivers/docker_driver.go
@@ -412,6 +412,7 @@ func (d *DockerDriver) GetConfig() (unversioned.Config, error) {
 		Workdir:      img.Config.WorkingDir,
 		ExposedPorts: ports,
 		Labels:       img.Config.Labels,
+		User:         img.Config.User,
 	}, nil
 }
 

--- a/pkg/drivers/host_driver.go
+++ b/pkg/drivers/host_driver.go
@@ -183,5 +183,6 @@ func (d *HostDriver) GetConfig() (unversioned.Config, error) {
 		Workdir:      config.WorkingDir,
 		ExposedPorts: ports,
 		Labels:       config.Labels,
+		User:         config.User,
 	}, nil
 }

--- a/pkg/drivers/tar_driver.go
+++ b/pkg/drivers/tar_driver.go
@@ -178,5 +178,6 @@ func (d *TarDriver) GetConfig() (unversioned.Config, error) {
 		Workdir:      config.WorkingDir,
 		ExposedPorts: ports,
 		Labels:       config.Labels,
+		User:         config.User,
 	}, nil
 }

--- a/pkg/types/unversioned/types.go
+++ b/pkg/types/unversioned/types.go
@@ -41,6 +41,7 @@ type Config struct {
 	Workdir      string
 	ExposedPorts []string
 	Labels       map[string]string
+	User         string
 }
 
 type TestResult struct {

--- a/pkg/types/v2/metadata.go
+++ b/pkg/types/v2/metadata.go
@@ -32,6 +32,7 @@ type MetadataTest struct {
 	Volumes          []string       `yaml:"volumes"`
 	UnmountedVolumes []string       `yaml:"unmountedVolumes"`
 	Labels           []types.Label  `yaml:"labels"`
+	User             string         `yaml:"user"`
 }
 
 func (mt MetadataTest) IsEmpty() bool {
@@ -41,6 +42,7 @@ func (mt MetadataTest) IsEmpty() bool {
 		mt.Entrypoint == nil &&
 		mt.Cmd == nil &&
 		mt.Workdir == "" &&
+		mt.User == "" &&
 		len(mt.Volumes) == 0 &&
 		len(mt.UnmountedVolumes) == 0 &&
 		len(mt.Labels) == 0
@@ -160,6 +162,11 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 
 	if mt.Workdir != "" && mt.Workdir != imageConfig.Workdir {
 		result.Errorf("Image workdir %s does not match config workdir: %s", imageConfig.Workdir, mt.Workdir)
+		result.Fail()
+	}
+
+	if mt.User != "" && mt.User != imageConfig.User {
+		result.Errorf("Image user %s does not match config user: %s", imageConfig.User, mt.User)
 		result.Fail()
 	}
 


### PR DESCRIPTION
Hello there! Thanks for this cool tool!

The issue #80 mentions some metadata Image fields that are not available.

This PR implements the support for the field "user" which defines the default user of a container.
This is really useful when you want to check that an image is not launching container as root by default :)

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>