### PR TITLE
Add test for unbound env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ of these checks are optional.
 
 - Env (`[]EnvVar`): A list of environment variable key/value pairs that should be set
 in the container. isRegex (*optional*) interpretes the value as regex.
+- UnboundEnv (`[]EnvVar`): A list of environment variable keys that should **NOT** be set
+in the container.
 - Labels (`[]Label`): A list of image labels key/value pairs that should be set on the
 container. isRegex (*optional*) interpretes the value as regex.
 - Entrypoint (`[]string`): The entrypoint of the container.

--- a/pkg/types/v2/metadata.go
+++ b/pkg/types/v2/metadata.go
@@ -24,6 +24,7 @@ import (
 
 type MetadataTest struct {
 	Env              []types.EnvVar `yaml:"env"`
+	UnboundEnv       []types.EnvVar `yaml:"unboundEnv"`
 	ExposedPorts     []string       `yaml:"exposedPorts"`
 	UnexposedPorts   []string       `yaml:"unexposedPorts"`
 	Entrypoint       *[]string      `yaml:"entrypoint"`
@@ -37,6 +38,7 @@ type MetadataTest struct {
 
 func (mt MetadataTest) IsEmpty() bool {
 	return len(mt.Env) == 0 &&
+		len(mt.UnboundEnv) == 0 &&
 		len(mt.ExposedPorts) == 0 &&
 		len(mt.UnexposedPorts) == 0 &&
 		mt.Entrypoint == nil &&
@@ -110,6 +112,13 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 			}
 		} else {
 			result.Errorf("variable %s not found in image env", pair.Key)
+			result.Fail()
+		}
+	}
+
+	for _, pair := range mt.UnboundEnv {
+		if _, ok := imageConfig.Env[pair.Key]; ok {
+			result.Errorf("env variable %s found in image metadata", pair.Key)
 			result.Fail()
 		}
 	}

--- a/pkg/types/v2/metadata.go
+++ b/pkg/types/v2/metadata.go
@@ -118,7 +118,7 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 
 	for _, pair := range mt.UnboundEnv {
 		if _, ok := imageConfig.Env[pair.Key]; ok {
-			result.Errorf("env variable %s found in image metadata", pair.Key)
+			result.Errorf("env variable %s should not be present in image metadata", pair.Key)
 			result.Fail()
 		}
 	}

--- a/tests/amd64/ubuntu_20_04_metadata_test.yaml
+++ b/tests/amd64/ubuntu_20_04_metadata_test.yaml
@@ -10,6 +10,8 @@ metadataTest:
   - key: 'REGEX_VAR'
     value: '[a-z]+-2\.1\.*'
     isRegex: true
+  unboundEnv:
+  - key: 'BAR_FOO'
   labels:
   - key: 'localnet.localdomain.commit_hash'
     value: '0123456789abcdef0123456789abcdef01234567'

--- a/tests/arm64/ubuntu_20_04_metadata_test.yaml
+++ b/tests/arm64/ubuntu_20_04_metadata_test.yaml
@@ -10,6 +10,8 @@ metadataTest:
   - key: 'REGEX_VAR'
     value: '[a-z]+-2\.1\.*'
     isRegex: true
+  unboundEnv:
+  - key: 'BAR_FOO'
   labels:
   - key: 'localnet.localdomain.commit_hash'
     value: '0123456789abcdef0123456789abcdef01234567'

--- a/tests/ppc64le/ubuntu_20_04_metadata_test.yaml
+++ b/tests/ppc64le/ubuntu_20_04_metadata_test.yaml
@@ -10,6 +10,8 @@ metadataTest:
   - key: 'REGEX_VAR'
     value: '[a-z]+-2\.1\.*'
     isRegex: true
+  unboundEnv:
+  - key: 'BAR_FOO'
   labels:
   - key: 'localnet.localdomain.commit_hash'
     value: '0123456789abcdef0123456789abcdef01234567'

--- a/tests/s390x/ubuntu_20_04_metadata_test.yaml
+++ b/tests/s390x/ubuntu_20_04_metadata_test.yaml
@@ -10,6 +10,8 @@ metadataTest:
   - key: 'REGEX_VAR'
     value: '[a-z]+-2\.1\.*'
     isRegex: true
+  unboundEnv:
+  - key: 'BAR_FOO'
   labels:
   - key: 'localnet.localdomain.commit_hash'
     value: '0123456789abcdef0123456789abcdef01234567'


### PR DESCRIPTION
This will check the metadata whether the specified env variables really aren't present.

Fixes #281

Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>