### PR TITLE
Let Go 1.17 build the binaries

### DIFF
--- a/deploy/Dockerfile.build
+++ b/deploy/Dockerfile.build
@@ -1,5 +1,5 @@
 # Dockerfile used to build a build step that builds container-structure-test in CI.
-FROM golang:1.9
+FROM golang:1.17
 RUN apt-get update && apt-get install make
 RUN mkdir -p /go/src/github.com/GoogleContainerTools
 RUN ln -s /workspace /go/src/github.com/GoogleContainerTools/container-structure-test


### PR DESCRIPTION
Uses the latest release of Go available.

Fixes #286 