### PR TITLE
Use os.Lstat over os.Stat

### DIFF
--- a/pkg/drivers/host_driver.go
+++ b/pkg/drivers/host_driver.go
@@ -28,7 +28,7 @@ import (
 	"bytes"
 
 	"github.com/GoogleContainerTools/container-structure-test/pkg/types/unversioned"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 type HostDriver struct {
@@ -140,7 +140,7 @@ func (d *HostDriver) ProcessCommand(envVars []unversioned.EnvVar, fullCommand []
 }
 
 func (d *HostDriver) StatFile(path string) (os.FileInfo, error) {
-	return os.Stat(path)
+	return os.Lstat(path)
 }
 
 func (d *HostDriver) ReadFile(path string) ([]byte, error) {

--- a/pkg/drivers/tar_driver.go
+++ b/pkg/drivers/tar_driver.go
@@ -25,7 +25,7 @@ import (
 
 	pkgutil "github.com/GoogleContainerTools/container-diff/pkg/util"
 	"github.com/GoogleContainerTools/container-structure-test/pkg/types/unversioned"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 )
 
@@ -139,7 +139,7 @@ func (d *TarDriver) ProcessCommand(_ []unversioned.EnvVar, _ []string) (string, 
 }
 
 func (d *TarDriver) StatFile(path string) (os.FileInfo, error) {
-	return os.Stat(filepath.Join(d.Image.FSPath, path))
+	return os.Lstat(filepath.Join(d.Image.FSPath, path))
 }
 
 func (d *TarDriver) ReadFile(path string) ([]byte, error) {


### PR DESCRIPTION
@midnightconman @charlyx this is a recreation of https://github.com/GoogleContainerTools/container-structure-test/pull/247 with integration tests running on it!