### PR TITLE
docs: add homebrew install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Tests can be run either through a standalone binary, or through a Docker image.
 ## Installation
 
 ### OS X
+
+Install via [brew](https://brew.sh/):
+
+```bash
+$ brew install container-structure-test
+```
+
 ```shell
 curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-darwin-amd64 && chmod +x container-structure-test-darwin-amd64 && sudo mv container-structure-test-darwin-amd64 /usr/local/bin/container-structure-test
 ```


### PR DESCRIPTION
relates to #286

```
$ brew install container-structure-test
...
🍺  /usr/local/Cellar/container-structure-test/1.10.0: 6 files, 12.8MB
```

```
$ container-structure-test
container-structure-test provides a powerful framework to validate
the structure of a container image.
These tests can be used to check the output of commands in an image,
as well as verify metadata and contents of the filesystem.
```

cc @wndhydrnt @nkubala