### PR TITLE
Update the version of go -> 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleContainerTools/container-structure-test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/GoogleContainerTools/container-diff v0.14.1-0.20190219205308-3f6b025c016c


### PR DESCRIPTION
Current version of go in the package from last build is 1.17.3, which has following vulnerability
+------------------ +----------  +------+-------------------+------------------------------------+--------------------------+-------------
|       CVE                   |  SEVERITY | CVSS |        PACKAGE        |              VERSION               |          STATUS                                               
+------------------ + ---------- +------+-------------------+------------------------------------+--------------------------+-------------
| CVE-2022-23806   |  critical     | 9.10    |         go                    | 1.17.3                                  | fixed in 1.17.7, 1.16.14 |