### PR TITLE
fix JUnit report format

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -69,7 +70,43 @@ func FinalResults(out io.Writer, format types.OutputValue, result types.SummaryO
 	}
 
 	if format == types.Junit {
-		res, err := xml.Marshal(result)
+		type JUnitTestCase struct {
+			Name string			`xml:"name,attr"`
+			Errors   []string	`xml:"failure"`
+			Duration float64	`xml:"time,attr"`
+		}
+		type JUnitTestSuite struct {
+			Name string					`xml:"name,attr"`
+			Results []*JUnitTestCase	`xml:"testcase"`
+		}
+		junit_cases := []*JUnitTestCase{}
+		for elem := range result.Results {
+			r := result.Results[elem]
+			junit_cases = append(junit_cases, &JUnitTestCase{
+				Name:		r.Name,
+				Errors:		r.Errors,
+				Duration:	r.Duration.Seconds(),
+			})
+		}
+		junit_result := struct {
+			XMLName		xml.Name		`xml:"testsuites"`
+			Pass		int				`xml:"-"`
+			Fail		int				`xml:"failures,attr"`
+			Total		int				`xml:"tests,attr"`
+			Duration	float64			`xml:"time,attr"`
+			TestSuite	JUnitTestSuite	`xml:"testsuite"`
+		}	{
+			XMLName: result.XMLName,
+			Pass: result.Pass,
+			Fail: result.Fail,
+			Total: result.Total,
+			Duration: time.Duration.Seconds(result.Duration), // JUnit expects durations as float of seconds
+			TestSuite: JUnitTestSuite{
+				Name: "container-structure-test.test",
+				Results: junit_cases,
+			},
+		}
+		res, err := xml.Marshal(junit_result)
 		if err != nil {
 			return errors.Wrap(err, "marshalling xml")
 		}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -97,10 +97,12 @@ func FinalResults(out io.Writer, format types.OutputValue, result types.SummaryO
 				Results:	junit_cases,
 			},
 		}
-		res, err := xml.Marshal(junit_result)
+		res := []byte(strings.ReplaceAll(xml.Header, "\n", ""))
+		marshalled, err := xml.Marshal(junit_result)
 		if err != nil {
 			return errors.Wrap(err, "marshalling xml")
 		}
+		res = append(res, marshalled...)
 		res = append(res, []byte("\n")...)
 		_, err = out.Write(res)
 		return err

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -70,40 +70,31 @@ func FinalResults(out io.Writer, format types.OutputValue, result types.SummaryO
 	}
 
 	if format == types.Junit {
-		type JUnitTestCase struct {
-			Name string			`xml:"name,attr"`
-			Errors   []string	`xml:"failure"`
-			Duration float64	`xml:"time,attr"`
-		}
-		type JUnitTestSuite struct {
-			Name string					`xml:"name,attr"`
-			Results []*JUnitTestCase	`xml:"testcase"`
-		}
-		junit_cases := []*JUnitTestCase{}
+		junit_cases := []*types.JUnitTestCase{}
 		for elem := range result.Results {
 			r := result.Results[elem]
-			junit_cases = append(junit_cases, &JUnitTestCase{
-				Name:		r.Name,
-				Errors:		r.Errors,
-				Duration:	r.Duration.Seconds(),
+			junit_cases = append(junit_cases, &types.JUnitTestCase{
+				Name:     r.Name,
+				Errors:   r.Errors,
+				Duration: r.Duration.Seconds(),
 			})
 		}
 		junit_result := struct {
-			XMLName		xml.Name		`xml:"testsuites"`
-			Pass		int				`xml:"-"`
-			Fail		int				`xml:"failures,attr"`
-			Total		int				`xml:"tests,attr"`
-			Duration	float64			`xml:"time,attr"`
-			TestSuite	JUnitTestSuite	`xml:"testsuite"`
+			XMLName   xml.Name             `xml:"testsuites"`
+			Pass      int                  `xml:"-"`
+			Fail      int                  `xml:"failures,attr"`
+			Total     int                  `xml:"tests,attr"`
+			Duration  float64              `xml:"time,attr"`
+			TestSuite types.JUnitTestSuite `xml:"testsuite"`
 		}	{
-			XMLName: result.XMLName,
-			Pass: result.Pass,
-			Fail: result.Fail,
-			Total: result.Total,
-			Duration: time.Duration.Seconds(result.Duration), // JUnit expects durations as float of seconds
-			TestSuite: JUnitTestSuite{
-				Name: "container-structure-test.test",
-				Results: junit_cases,
+			XMLName:	result.XMLName,
+			Pass:		result.Pass,
+			Fail:		result.Fail,
+			Total:		result.Total,
+			Duration:	time.Duration.Seconds(result.Duration), // JUnit expects durations as float of seconds
+			TestSuite:	types.JUnitTestSuite{
+				Name:		"container-structure-test.test",
+				Results:	junit_cases,
 			},
 		}
 		res, err := xml.Marshal(junit_result)

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -44,7 +44,7 @@ func TestFinalResults(t *testing.T) {
 		{
 			actual:   bytes.NewBuffer([]byte{}),
 			format:   unversioned.Junit,
-			expected: `<testsuites failures="1" tests="2" time="2e-09"><testsuite name="container-structure-test.test"><testcase name="my first test" time="1e-09"></testcase><testcase name="my fail" time="1e-09"><failure>this failed because of that</failure></testcase></testsuite></testsuites>`,
+			expected: `<?xml version="1.0" encoding="UTF-8"?><testsuites failures="1" tests="2" time="2e-09"><testsuite name="container-structure-test.test"><testcase name="my first test" time="1e-09"></testcase><testcase name="my fail" time="1e-09"><failure>this failed because of that</failure></testcase></testsuite></testsuites>`,
 		},
 		{
 			actual:   bytes.NewBuffer([]byte{}),

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -44,7 +44,7 @@ func TestFinalResults(t *testing.T) {
 		{
 			actual:   bytes.NewBuffer([]byte{}),
 			format:   unversioned.Junit,
-			expected: `<testsuites failures="1" tests="2" time="2"><testsuite><testcase name="my first test" time="1"></testcase><testcase name="my fail" time="1"><failure>this failed because of that</failure></testcase></testsuite></testsuites>`,
+			expected: `<testsuites failures="1" tests="2" time="2e-09"><testsuite name="container-structure-test.test"><testcase name="my first test" time="1e-09"></testcase><testcase name="my fail" time="1e-09"><failure>this failed because of that</failure></testcase></testsuite></testsuites>`,
 		},
 		{
 			actual:   bytes.NewBuffer([]byte{}),

--- a/pkg/types/unversioned/types.go
+++ b/pkg/types/unversioned/types.go
@@ -96,6 +96,17 @@ type SummaryObject struct {
 	Results  []*TestResult `json:",omitempty" xml:"testsuite>testcase"`
 }
 
+type JUnitTestSuite struct {
+	Name    string           `xml:"name,attr"`
+	Results []*JUnitTestCase `xml:"testcase"`
+}
+
+type JUnitTestCase struct {
+	Name     string   `xml:"name,attr"`
+	Errors   []string `xml:"failure"`
+	Duration float64  `xml:"time,attr"`
+}
+
 type OutputValue int
 
 const (

--- a/tests/amd64/ubuntu_20_04_failure_test.yaml
+++ b/tests/amd64/ubuntu_20_04_failure_test.yaml
@@ -3,11 +3,11 @@ commandTests:
 - name: 'bad apt-get-command'
   command: ['apt-get', 'dslkfjasl']
   excludedError: ['.*FAIL.*']
-  expectedOutput: ['.*Usage.*']
+  expectedError: ['.*Invalid operation dslkfjasl.*']
+  exitCode: 1
 - name: 'apt-config'
   command: ['apt-config', 'dump']
-  expectedOutput: ['Acquire::Retries "3"']
-  name: 'apt-config'
+  expectedOutput: ['DPkg::Pre-Install-Pkgs "";']
 - name: 'path'
   command: ['sh', '-c', 'echo $PATH']
   expectedOutput: ['/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin']

--- a/tests/amd64/ubuntu_20_04_test.yaml
+++ b/tests/amd64/ubuntu_20_04_test.yaml
@@ -16,7 +16,7 @@ commandTests:
 fileContentTests:
 - name: 'Debian Sources'
   excludedContents: ['.*gce_debian_mirror.*']
-  expectedContents: ['.*archive\.ubuntu\.com.*']
+  expectedContents: ['.*archive\.canonical\.com.*']
   path: '/etc/apt/sources.list'
 - name: 'Passwd file'
   expectedContents: ['root:x:0:0:root:/root:/bin/bash']

--- a/tests/amd64/ubuntu_20_04_test.yaml
+++ b/tests/amd64/ubuntu_20_04_test.yaml
@@ -16,7 +16,7 @@ commandTests:
 fileContentTests:
 - name: 'Debian Sources'
   excludedContents: ['.*gce_debian_mirror.*']
-  expectedContents: ['.*archive\.canonical\.com.*']
+  expectedContents: ['.*archive\.ubuntu\.com.*']
   path: '/etc/apt/sources.list'
 - name: 'Passwd file'
   expectedContents: ['root:x:0:0:root:/root:/bin/bash']

--- a/tests/structure_test_tests.sh
+++ b/tests/structure_test_tests.sh
@@ -131,7 +131,7 @@ echo "###"
 echo "# OCI layout test case"
 echo "###"
 
-go install github.com/google/go-containerregistry/cmd/crane/cmd
+go install github.com/google/go-containerregistry/cmd/crane
 tmp="$(mktemp -d)"
 
 crane pull "$test_image" --format=oci "$tmp" --platform=linux/arm64

--- a/tests/structure_test_tests.sh
+++ b/tests/structure_test_tests.sh
@@ -134,7 +134,8 @@ echo "###"
 go install github.com/google/go-containerregistry/cmd/crane/cmd
 tmp="$(mktemp -d)"
 
-crane pull "$test_image" --format=oci "$tmp" --platform=linux/arm64
+
+crane pull "$test_image" --format=oci "$tmp" --platform=linux/${go_architecture}
 
 
 res=$(./out/container-structure-test test --image-from-oci-layout="$tmp" --config "${test_config_dir}/ubuntu_20_04_test.yaml" 2>&1)

--- a/tests/structure_test_tests.sh
+++ b/tests/structure_test_tests.sh
@@ -131,7 +131,7 @@ echo "###"
 echo "# OCI layout test case"
 echo "###"
 
-go install github.com/google/go-containerregistry/cmd/crane
+go install github.com/google/go-containerregistry/cmd/crane/cmd
 tmp="$(mktemp -d)"
 
 crane pull "$test_image" --format=oci "$tmp" --platform=linux/arm64


### PR DESCRIPTION
Fixes #273 & #304

I added two new types to handle the JUnit specific marshaling. This probably can be implemented a bit better rather than inline structs + new types just for making encoding/xml happy.

tests pass. Had to make a tweak to tests/structure_test_tests.sh get the script to run correctly. Could use a pair of eyes to make sure its kosher 👀 
```bash
$ make test
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags " -X github.com/GoogleContainerTools/container-structure-test/pkg/version.version=v1.11.0 -X github.com/GoogleContainerTools/container-structure-test/pkg/version.buildDate=2022-09-10T23:12:32Z " -o out/container-structure-test-linux-amd64 github.com/GoogleContainerTools/container-structure-test/cmd/container-structure-test
cp ./out/container-structure-test-linux-amd64 out/container-structure-test
./tests/structure_test_tests.sh
##
# Build the newest 'container structure test' binary
##
make[1]: Entering directory '/home/tom/oss/container-structure-test'
make[1]: 'out/container-structure-test' is up to date.
make[1]: Leaving directory '/home/tom/oss/container-structure-test'
make[1]: Entering directory '/home/tom/oss/container-structure-test'
shasum -a 256 out/container-structure-test-linux-amd64 &> out/container-structure-test-linux-amd64.sha256
GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags " -X github.com/GoogleContainerTools/container-structure-test/pkg/version.version=v1.11.0 -X github.com/GoogleContainerTools/container-structure-test/pkg/version.buildDate=2022-09-10T23:12:33Z " -o out/container-structure-test-darwin-amd64 github.com/GoogleContainerTools/container-structure-test/cmd/container-structure-test
1af7e99e80ab87be17e42c2215775213b00bf26b94d912e841e13074c2aa1e28  out/container-structure-test-linux-amd64
shasum -a 256 out/container-structure-test-darwin-amd64 &> out/container-structure-test-darwin-amd64.sha256
GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags " -X github.com/GoogleContainerTools/container-structure-test/pkg/version.version=v1.11.0 -X github.com/GoogleContainerTools/container-structure-test/pkg/version.buildDate=2022-09-10T23:12:33Z " -o out/container-structure-test-windows-amd64 github.com/GoogleContainerTools/container-structure-test/cmd/container-structure-test
cb459a834dd408c3c49871996de887ef4869e1b3a39969ddbc5bbb40ea4eb5e3  out/container-structure-test-darwin-amd64
cp out/container-structure-test-windows-amd64 out/container-structure-test-windows-amd64.exe
shasum -a 256 out/container-structure-test-windows-amd64.exe &> out/container-structure-test-windows-amd64.exe.sha256
rm out/container-structure-test-windows-amd64
make[1]: Leaving directory '/home/tom/oss/container-structure-test'
make[1]: Entering directory '/home/tom/oss/container-structure-test'
docker build -t gcr.io/gcp-runtimes/container-structure-test:latest .
b52f3be912ee64f74d5ea8b976a1810c44d361b050ebdbcc30192549343fbd31  out/container-structure-test-windows-amd64.exe
Sending build context to Docker daemon   75.7MB
Step 1/3 : FROM ubuntu:20.04
 ---> a0ce5a295b63
Step 2/3 : ADD out/container-structure-test /container-structure-test
 ---> 0baf39323714
Step 3/3 : ENTRYPOINT ["/container-structure-test"]
 ---> Running in 45c8c2fdfbe1
Removing intermediate container 45c8c2fdfbe1
 ---> d6e10d9b923c
Successfully built d6e10d9b923c
Successfully tagged gcr.io/gcp-runtimes/container-structure-test:latest
make[1]: Leaving directory '/home/tom/oss/container-structure-test'
##
# Positive Test Case
##
PASS: Success test case passed
##
# Metadata Test Case
##
PASS: Metadata success test case for docker driver
PASS: Metadata success test case for tar driver
PASS: Metadata success test case for host driver
##
# Failure Test Case
##
FATA[0000] FAIL                                         
PASS: Failure test failed
###
# OCI layout test case
###
PASS: oci failing test case
PASS: oci success test case
```