### PR TITLE
Change env to envVars on metadataTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ container. isRegex (*optional*) interpretes the value as regex.
 Example:
 ```yaml
 metadataTest:
-  env:
+  envVars:
     - key: foo
       value: baz
   labels:


### PR DESCRIPTION
I forget to change document on previous pull request.
https://github.com/GoogleContainerTools/container-structure-test/pull/314