### PR TITLE
revert breaking change to metadata.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ of these checks are optional.
 
 #### Supported Fields:
 
-- EnvVars (`[]EnvVar`): A list of environment variable key/value pairs that should be set
+- Env (`[]EnvVar`): A list of environment variable key/value pairs that should be set
 in the container. isRegex (*optional*) interpretes the value as regex.
-- UnboundEnvVars (`[]EnvVar`): A list of environment variable keys that should **NOT** be set
+- UnboundEnv (`[]EnvVar`): A list of environment variable keys that should **NOT** be set
 in the container.
 - Labels (`[]Label`): A list of image labels key/value pairs that should be set on the
 container. isRegex (*optional*) interpretes the value as regex.
@@ -230,7 +230,7 @@ container. isRegex (*optional*) interpretes the value as regex.
 Example:
 ```yaml
 metadataTest:
-  envVars:
+  env:
     - key: foo
       value: baz
   labels:

--- a/pkg/types/v2/metadata.go
+++ b/pkg/types/v2/metadata.go
@@ -23,8 +23,8 @@ import (
 )
 
 type MetadataTest struct {
-	EnvVars          []types.EnvVar `yaml:"envVars"`
-	UnboundEnvVars   []types.EnvVar `yaml:"unboundEnvVars"`
+	Env              []types.EnvVar `yaml:"env"`
+	UnboundEnv       []types.EnvVar `yaml:"unboundEnv"`
 	ExposedPorts     []string       `yaml:"exposedPorts"`
 	UnexposedPorts   []string       `yaml:"unexposedPorts"`
 	Entrypoint       *[]string      `yaml:"entrypoint"`
@@ -37,8 +37,8 @@ type MetadataTest struct {
 }
 
 func (mt MetadataTest) IsEmpty() bool {
-	return len(mt.EnvVars) == 0 &&
-		len(mt.UnboundEnvVars) == 0 &&
+	return len(mt.Env) == 0 &&
+		len(mt.UnboundEnv) == 0 &&
 		len(mt.ExposedPorts) == 0 &&
 		len(mt.UnexposedPorts) == 0 &&
 		mt.Entrypoint == nil &&
@@ -58,7 +58,7 @@ func (mt MetadataTest) Validate(channel chan interface{}) bool {
 	res := &types.TestResult{
 		Name: mt.LogName(),
 	}
-	for _, envVar := range mt.EnvVars {
+	for _, envVar := range mt.Env {
 		if envVar.Key == "" {
 			res.Error("Environment variable key cannot be empty")
 		}
@@ -98,7 +98,7 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 		return result
 	}
 
-	for _, pair := range mt.EnvVars {
+	for _, pair := range mt.Env {
 		if val, ok := imageConfig.Env[pair.Key]; ok {
 			var match bool
 			if pair.IsRegex {
@@ -116,7 +116,7 @@ func (mt MetadataTest) Run(driver drivers.Driver) *types.TestResult {
 		}
 	}
 
-	for _, pair := range mt.UnboundEnvVars {
+	for _, pair := range mt.UnboundEnv {
 		if _, ok := imageConfig.Env[pair.Key]; ok {
 			result.Errorf("env variable %s should not be present in image metadata", pair.Key)
 			result.Fail()

--- a/tests/amd64/ubuntu_20_04_metadata_test.yaml
+++ b/tests/amd64/ubuntu_20_04_metadata_test.yaml
@@ -1,6 +1,6 @@
 schemaVersion: '2.0.0' # Make sure to test the latest schema version
 metadataTest:
-  envVars:
+  env:
   - key: 'SOME_KEY'
     value: 'SOME_VAL'
   - key: 'EMPTY_VAR'
@@ -10,7 +10,7 @@ metadataTest:
   - key: 'REGEX_VAR'
     value: '[a-z]+-2\.1\.*'
     isRegex: true
-  unboundEnvVars:
+  unboundEnv:
   - key: 'BAR_FOO'
   labels:
   - key: 'localnet.localdomain.commit_hash'

--- a/tests/arm64/ubuntu_20_04_metadata_test.yaml
+++ b/tests/arm64/ubuntu_20_04_metadata_test.yaml
@@ -1,6 +1,6 @@
 schemaVersion: '2.0.0' # Make sure to test the latest schema version
 metadataTest:
-  envVars:
+  env:
   - key: 'SOME_KEY'
     value: 'SOME_VAL'
   - key: 'EMPTY_VAR'
@@ -10,7 +10,7 @@ metadataTest:
   - key: 'REGEX_VAR'
     value: '[a-z]+-2\.1\.*'
     isRegex: true
-  unboundEnvVars:
+  unboundEnv:
   - key: 'BAR_FOO'
   labels:
   - key: 'localnet.localdomain.commit_hash'

--- a/tests/ppc64le/ubuntu_20_04_metadata_test.yaml
+++ b/tests/ppc64le/ubuntu_20_04_metadata_test.yaml
@@ -1,6 +1,6 @@
 schemaVersion: '2.0.0' # Make sure to test the latest schema version
 metadataTest:
-  envVars:
+  env:
   - key: 'SOME_KEY'
     value: 'SOME_VAL'
   - key: 'EMPTY_VAR'
@@ -10,7 +10,7 @@ metadataTest:
   - key: 'REGEX_VAR'
     value: '[a-z]+-2\.1\.*'
     isRegex: true
-  unboundEnvVars:
+  unboundEnv:
   - key: 'BAR_FOO'
   labels:
   - key: 'localnet.localdomain.commit_hash'

--- a/tests/s390x/ubuntu_20_04_metadata_test.yaml
+++ b/tests/s390x/ubuntu_20_04_metadata_test.yaml
@@ -1,6 +1,6 @@
 schemaVersion: '2.0.0' # Make sure to test the latest schema version
 metadataTest:
-  envVars:
+  env:
   - key: 'SOME_KEY'
     value: 'SOME_VAL'
   - key: 'EMPTY_VAR'
@@ -10,7 +10,7 @@ metadataTest:
   - key: 'REGEX_VAR'
     value: '[a-z]+-2\.1\.*'
     isRegex: true
-  unboundEnvVars:
+  unboundEnv:
   - key: 'BAR_FOO'
   labels:
   - key: 'localnet.localdomain.commit_hash'


### PR DESCRIPTION
I don't know if this is worth reverting since 1.13+ users have already updated tests to handle the break (myself included). Opening this PR as a point of discussion. I'd prefer remaining consistent with respect to schema versioning so I support reverting these changes completely. This allows for non-breaking upgrade path from 1.11 to the next release.

If others wish to not introduce another break between 1.13/1.14 and later versions, I'm happy to disregard this PR. 

closes #322

Revert "Refactor Metadata EnvVars and UnboundEnvVars on metadataTest (#314)"

This reverts commit 54fc3bfa71bacca64abce3c2cfe283be6b10f4cd.

Revert "Change env to envVars on metadataTest (#315)"

This reverts commit 77aaefb84a5428c76cc143075e517d4b1411da18.

