### PR TITLE
re-introduce env for compatibility

### DIFF
--- a/tests/amd64/ubuntu_20_04_metadata_env_test.yaml
+++ b/tests/amd64/ubuntu_20_04_metadata_env_test.yaml
@@ -1,0 +1,14 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+metadataTest:
+  env:
+  - key: 'SOME_KEY'
+    value: 'SOME_VAL'
+  - key: 'EMPTY_VAR'
+    value: ''
+  - key: 'FOO_BAR'
+    value: 'FOO\:BAR=BAZ'
+  - key: 'REGEX_VAR'
+    value: '[a-z]+-2\.1\.*'
+    isRegex: true
+  unboundEnv:
+  - key: 'BAR_FOO'

--- a/tests/amd64/ubuntu_20_04_metadata_failure_test.yaml
+++ b/tests/amd64/ubuntu_20_04_metadata_failure_test.yaml
@@ -1,0 +1,12 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+metadataTest:
+  env:
+  - key: 'SOME_KEY'
+    value: 'SOME_VAL'
+  envVars:
+    - key: 'OTHER_KEY'
+      value: 'SOME_VAL'
+  unboundEnv:
+  - key: 'BAR_FOO'
+  unboundEnvVars:
+  - key: 'BAZ_FOO'

--- a/tests/arm64/ubuntu_20_04_metadata_env_test.yaml
+++ b/tests/arm64/ubuntu_20_04_metadata_env_test.yaml
@@ -1,0 +1,14 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+metadataTest:
+  env:
+  - key: 'SOME_KEY'
+    value: 'SOME_VAL'
+  - key: 'EMPTY_VAR'
+    value: ''
+  - key: 'FOO_BAR'
+    value: 'FOO\:BAR=BAZ'
+  - key: 'REGEX_VAR'
+    value: '[a-z]+-2\.1\.*'
+    isRegex: true
+  unboundEnv:
+  - key: 'BAR_FOO'

--- a/tests/arm64/ubuntu_20_04_metadata_failure_test.yaml
+++ b/tests/arm64/ubuntu_20_04_metadata_failure_test.yaml
@@ -1,0 +1,12 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+metadataTest:
+  env:
+  - key: 'SOME_KEY'
+    value: 'SOME_VAL'
+  envVars:
+    - key: 'OTHER_KEY'
+      value: 'SOME_VAL'
+  unboundEnv:
+  - key: 'BAR_FOO'
+  unboundEnvVars:
+  - key: 'BAZ_FOO'

--- a/tests/ppc64le/ubuntu_20_04_metadata_env_test.yaml
+++ b/tests/ppc64le/ubuntu_20_04_metadata_env_test.yaml
@@ -1,0 +1,14 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+metadataTest:
+  env:
+  - key: 'SOME_KEY'
+    value: 'SOME_VAL'
+  - key: 'EMPTY_VAR'
+    value: ''
+  - key: 'FOO_BAR'
+    value: 'FOO\:BAR=BAZ'
+  - key: 'REGEX_VAR'
+    value: '[a-z]+-2\.1\.*'
+    isRegex: true
+  unboundEnv:
+  - key: 'BAR_FOO'

--- a/tests/ppc64le/ubuntu_20_04_metadata_failure_test.yaml
+++ b/tests/ppc64le/ubuntu_20_04_metadata_failure_test.yaml
@@ -1,0 +1,12 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+metadataTest:
+  env:
+  - key: 'SOME_KEY'
+    value: 'SOME_VAL'
+  envVars:
+    - key: 'OTHER_KEY'
+      value: 'SOME_VAL'
+  unboundEnv:
+  - key: 'BAR_FOO'
+  unboundEnvVars:
+  - key: 'BAZ_FOO'

--- a/tests/s390x/ubuntu_20_04_metadata_env_test.yaml
+++ b/tests/s390x/ubuntu_20_04_metadata_env_test.yaml
@@ -1,0 +1,14 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+metadataTest:
+  env:
+  - key: 'SOME_KEY'
+    value: 'SOME_VAL'
+  - key: 'EMPTY_VAR'
+    value: ''
+  - key: 'FOO_BAR'
+    value: 'FOO\:BAR=BAZ'
+  - key: 'REGEX_VAR'
+    value: '[a-z]+-2\.1\.*'
+    isRegex: true
+  unboundEnv:
+  - key: 'BAR_FOO'

--- a/tests/s390x/ubuntu_20_04_metadata_failure_test.yaml
+++ b/tests/s390x/ubuntu_20_04_metadata_failure_test.yaml
@@ -1,0 +1,12 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+metadataTest:
+  env:
+  - key: 'SOME_KEY'
+    value: 'SOME_VAL'
+  envVars:
+    - key: 'OTHER_KEY'
+      value: 'SOME_VAL'
+  unboundEnv:
+  - key: 'BAR_FOO'
+  unboundEnvVars:
+  - key: 'BAZ_FOO'

--- a/tests/structure_test_tests.sh
+++ b/tests/structure_test_tests.sh
@@ -107,6 +107,17 @@ then
     echo "PASS: Metadata success test case for docker driver"
   fi
 
+  res=$(./out/container-structure-test test --image "$test_metadata_image" --config "${test_config_dir}/ubuntu_20_04_metadata_env_test.yaml")
+  code=$?
+  if ! [[ ("$res" =~ "PASS" && "$code" == "0") ]];
+  then
+    echo "FAIL: Metadata env var success test case for docker driver"
+    echo "$res"
+    failures=$((failures +1))
+  else
+    echo "PASS: Metadata env var success test case for docker driver"
+  fi
+
   docker save "$test_metadata_image" -o "$test_metadata_tar" > /dev/null
   res=$(./out/container-structure-test test --driver tar --image "$test_metadata_tar" --config "${test_config_dir}/ubuntu_20_04_metadata_test.yaml")
   code=$?
@@ -117,6 +128,17 @@ then
     failures=$((failures +1))
   else
     echo "PASS: Metadata success test case for tar driver"
+  fi
+
+  res=$(./out/container-structure-test test --driver tar --image "$test_metadata_image" --config "${test_config_dir}/ubuntu_20_04_metadata_env_test.yaml")
+  code=$?
+  if ! [[ ("$res" =~ "PASS" && "$code" == "0") ]];
+  then
+    echo "FAIL: Metadata env var success test case for tar driver"
+    echo "$res"
+    failures=$((failures +1))
+  else
+    echo "PASS: Metadata env var success test case for tar driver"
   fi
 
   mkdir -p "$test_metadata_dir"
@@ -131,6 +153,17 @@ then
     failures=$((failures +1))
   else
     echo "PASS: Metadata success test case for host driver"
+  fi
+
+  res=$(./out/container-structure-test test --driver host --force --metadata "$test_metadata_dir/$test_metadata_json" --config "${test_config_dir}/ubuntu_20_04_metadata_env_test.yaml")
+  code=$?
+  if ! [[ ("$res" =~ "PASS" && "$code" == "0") ]];
+  then
+    echo "FAIL: Metadata env var success test case for host driver"
+    echo "$res"
+    failures=$((failures +1))
+  else
+    echo "PASS: Metadata env var success test case for host driver"
   fi
 
   rm -rf "$test_metadata_dir"
@@ -153,7 +186,16 @@ else
   echo "PASS: Failure test failed"
 fi
 
-
+res=$(./out/container-structure-test test --image "$test_image" --config "${test_config_dir}/ubuntu_20_04_metadata_failure_test.yaml")
+code=$?
+if ! [[ ("$res" =~ "FAIL" && "$code" == "1") ]];
+then
+  echo "FAIL: Metadata failure test case did not fail"
+  echo "$res"
+  failures=$((failures +1))
+else
+  echo "PASS: Metadata failure test failed"
+fi
 
 HEADER "OCI layout test case"
 


### PR DESCRIPTION
Re-add `env` and `unboundEnv` to MetadataTest to allow for backwards/forwards compatibility between 1.11 & earlier and subsequent future releases (> 1.14).

Add deprecation warning for `env` and `unboundEnv` (remove it in next schema version)

TODO:
- [ ] Update the documentation to include both fields as well as deprecation notice for `env`

Related: 
#313 
#314 
#322 