### PR TITLE
Add stdout and stderr to JUnit test results

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -77,6 +77,8 @@ func FinalResults(out io.Writer, format types.OutputValue, result types.SummaryO
 				Name:     r.Name,
 				Errors:   r.Errors,
 				Duration: r.Duration.Seconds(),
+				Stdout:   r.Stdout,
+				Stderr:   r.Stderr,
 			})
 		}
 		junit_result := struct {

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -44,7 +44,7 @@ func TestFinalResults(t *testing.T) {
 		{
 			actual:   bytes.NewBuffer([]byte{}),
 			format:   unversioned.Junit,
-			expected: `<?xml version="1.0" encoding="UTF-8"?><testsuites failures="1" tests="2" time="2e-09"><testsuite name="container-structure-test.test"><testcase name="my first test" time="1e-09"></testcase><testcase name="my fail" time="1e-09"><failure>this failed because of that</failure></testcase></testsuite></testsuites>`,
+			expected: `<?xml version="1.0" encoding="UTF-8"?><testsuites failures="1" tests="2" time="2e-09"><testsuite name="container-structure-test.test"><testcase name="my first test" time="1e-09"><system-out>it works!</system-out><system-err></system-err></testcase><testcase name="my fail" time="1e-09"><failure>this failed because of that</failure><system-out></system-out><system-err>this failed</system-err></testcase></testsuite></testsuites>`,
 		},
 		{
 			actual:   bytes.NewBuffer([]byte{}),

--- a/pkg/types/unversioned/types.go
+++ b/pkg/types/unversioned/types.go
@@ -125,6 +125,8 @@ type JUnitTestCase struct {
 	Name     string   `xml:"name,attr"`
 	Errors   []string `xml:"failure"`
 	Duration float64  `xml:"time,attr"`
+	Stdout   string   `xml:"system-out"`
+	Stderr   string   `xml:"system-err"`
 }
 
 type OutputValue int


### PR DESCRIPTION
Add the contents of stdout and stderr when creating junit test results.

I'm not sure if there is a formal definition of junit, so I followed https://github.com/testmoapp/junitxml and it seems to work in CircleCI.

(I couldn't see a pull request template, I'll be happy to add anything necessary)