### PR TITLE
feat: Add support for --cap-drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ containerRunOptions:
     - OTHER_SECRET_BAR
   capabilities:                 # Add list of Linux capabilities (--cap-add)
     - NET_BIND_SERVICE
+  drop_capabilities:            # Drop list of Linux capabilities (--cap-drop)
+    - NET_BIND_SERVICE
   bindMounts:                   # Bind mount a volume (--volume, -v)
     - /etc/example/dir:/etc/dir
 ```

--- a/pkg/drivers/docker_driver.go
+++ b/pkg/drivers/docker_driver.go
@@ -19,12 +19,13 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/joho/godotenv"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/joho/godotenv"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -66,17 +67,19 @@ func NewDockerDriver(args DriverConfig) (Driver, error) {
 func (d *DockerDriver) hostConfig() *docker.HostConfig {
 	if d.runOpts.IsSet() && d.runtime != "" {
 		return &docker.HostConfig{
-			Capabilities: d.runOpts.Capabilities,
-			Binds:        d.runOpts.BindMounts,
-			Privileged:   d.runOpts.Privileged,
-			Runtime:      d.runtime,
+			CapAdd:     d.runOpts.CapAdd,
+			CapDrop:    d.runOpts.CapDrop,
+			Binds:      d.runOpts.BindMounts,
+			Privileged: d.runOpts.Privileged,
+			Runtime:    d.runtime,
 		}
 	}
 	if d.runOpts.IsSet() {
 		return &docker.HostConfig{
-			Capabilities: d.runOpts.Capabilities,
-			Binds:        d.runOpts.BindMounts,
-			Privileged:   d.runOpts.Privileged,
+			CapAdd:     d.runOpts.CapAdd,
+			CapDrop:    d.runOpts.CapDrop,
+			Binds:      d.runOpts.BindMounts,
+			Privileged: d.runOpts.Privileged,
 		}
 	}
 	if d.runtime != "" {

--- a/pkg/types/unversioned/types.go
+++ b/pkg/types/unversioned/types.go
@@ -45,13 +45,14 @@ type Config struct {
 }
 
 type ContainerRunOptions struct {
-	User         string
-	Privileged   bool
-	TTY          bool     `yaml:"allocateTty"`
-	EnvVars      []string `yaml:"envVars"`
-	EnvFile      string   `yaml:"envFile"`
-	Capabilities []string
-	BindMounts   []string `yaml:"bindMounts"`
+	User       string
+	Privileged bool
+	TTY        bool     `yaml:"allocateTty"`
+	EnvVars    []string `yaml:"envVars"`
+	EnvFile    string   `yaml:"envFile"`
+	CapAdd     []string `yaml:"capabilities"`
+	CapDrop    []string `yaml:"drop_capabilities"`
+	BindMounts []string `yaml:"bindMounts"`
 }
 
 func (opts *ContainerRunOptions) IsSet() bool {
@@ -60,7 +61,8 @@ func (opts *ContainerRunOptions) IsSet() bool {
 		opts.TTY ||
 		len(opts.EnvFile) > 0 ||
 		(opts.EnvVars != nil && len(opts.EnvVars) > 0) ||
-		(opts.Capabilities != nil && len(opts.Capabilities) > 0) ||
+		(opts.CapAdd != nil && len(opts.CapAdd) > 0) ||
+		(opts.CapDrop != nil && len(opts.CapDrop) > 0) ||
 		(opts.BindMounts != nil && len(opts.BindMounts) > 0)
 }
 

--- a/tests/amd64/ubuntu_22_04_containeropts_test.yaml
+++ b/tests/amd64/ubuntu_22_04_containeropts_test.yaml
@@ -5,6 +5,8 @@ commandTests:
   args: ["--print"]
   expectedOutput:
     - ".*cap_sys_admin.*"
+  excludedOutput:
+    - ".*chown.*"
 - name: "Test bindMounts containerRunOptions"
   command: "test"
   args:
@@ -15,5 +17,7 @@ containerRunOptions:
   privileged: true
   capabilities:
     - "sys_admin"
+  drop_capabilities:
+    - "chown"
   bindMounts:
     - "/tmp/test:/tmp/test"

--- a/tests/arm64/ubuntu_22_04_containeropts_test.yaml
+++ b/tests/arm64/ubuntu_22_04_containeropts_test.yaml
@@ -5,6 +5,8 @@ commandTests:
   args: ["--print"]
   expectedOutput:
     - ".*cap_sys_admin.*"
+  excludedOutput:
+    - ".*chown.*"
 - name: "Test bindMounts containerRunOptions"
   command: "test"
   args:
@@ -15,5 +17,7 @@ containerRunOptions:
   privileged: true
   capabilities:
     - "sys_admin"
+  drop_capabilities:
+    - "chown"
   bindMounts:
     - "/tmp/test:/tmp/test"

--- a/tests/ppc64le/ubuntu_22_04_containeropts_test.yaml
+++ b/tests/ppc64le/ubuntu_22_04_containeropts_test.yaml
@@ -5,6 +5,8 @@ commandTests:
   args: ["--print"]
   expectedOutput:
     - ".*cap_sys_admin.*"
+  excludedOutput:
+    - ".*chown.*"
 - name: "Test bindMounts containerRunOptions"
   command: "test"
   args:
@@ -15,5 +17,7 @@ containerRunOptions:
   privileged: true
   capabilities:
     - "sys_admin"
+  drop_capabilities:
+    - "chown"
   bindMounts:
     - "/tmp/test:/tmp/test"

--- a/tests/s390x/ubuntu_22_04_containeropts_test.yaml
+++ b/tests/s390x/ubuntu_22_04_containeropts_test.yaml
@@ -5,6 +5,8 @@ commandTests:
   args: ["--print"]
   expectedOutput:
     - ".*cap_sys_admin.*"
+  excludedOutput:
+    - ".*chown.*"
 - name: "Test bindMounts containerRunOptions"
   command: "test"
   args:
@@ -15,5 +17,7 @@ containerRunOptions:
   privileged: true
   capabilities:
     - "sys_admin"
+  drop_capabilities:
+    - "chown"
   bindMounts:
     - "/tmp/test:/tmp/test"


### PR DESCRIPTION
- Support for --cap-add was added as part of
   https://github.com/GoogleContainerTools/container-structure-test/pull/327

 - This rounds out the feature set to also include support for
   --cap-drop

 - Updates tests to drop "chown" capability and verify doing so works

 - closes https://github.com/GoogleContainerTools/container-structure-test/issues/389


FYI - `make test` fails against the head of the main branch on my M1 -- which I didn't have time to diagnose. I'm using CI to verify that the tests behave properly.