### PR TITLE
Add support for darwin/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,11 @@ VERSION_PACKAGE := $(REPOPATH)/pkg/version
 ifeq ($(GOARCH), amd64)
 SUPPORTED_PLATFORMS := linux-$(GOARCH) darwin-$(GOARCH) windows-$(GOARCH).exe
 else
+ifeq ($(GOARCH), arm64)
+SUPPORTED_PLATFORMS := linux-$(GOARCH) darwin-$(GOARCH)
+else
 SUPPORTED_PLATFORMS := linux-$(GOARCH)
+endif
 endif
 
 GO_LDFLAGS :="


### PR DESCRIPTION
Hello `container-structure-test` maintainers!

My company has moved most of its Engineering team to M1 machines, we still use `container-structure-test` in our `amd64` build pipelines but we would also like to be able to run it more easily while developing locally. I have tested adding the `darwin/arm64` target to the Makefile and it appears to be functioning as expected. Looking through your ci yamls, I believe the repo is already set up to handle this addition seamlessly but please let me know if I missed something. I purposely did not follow the release procedure since that seems like a separate PR/core maintainer concern but I'm happy to adjust if requested.

Thanks for your help!

## Tests
```shell
make test
cp ./out/container-structure-test-darwin-arm64 out/container-structure-test
./tests/structure_test_tests.sh

###############
# Determine the runtime
###############

Using docker at /Users/nate.gay/bin/docker

###############
# Build the newest 'container structure test' binary
###############

GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags " -X github.com/GoogleContainerTools/container-structure-test/pkg/version.version=v1.16.0 -X github.com/GoogleContainerTools/container-structure-test/pkg/version.buildDate=2024-02-05T10:41:47Z " -o out/container-structure-test-darwin-arm64 github.com/GoogleContainerTools/container-structure-test/cmd/container-structure-test
cp ./out/container-structure-test-darwin-arm64 out/container-structure-test
GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags " -X github.com/GoogleContainerTools/container-structure-test/pkg/version.version=v1.16.0 -X github.com/GoogleContainerTools/container-structure-test/pkg/version.buildDate=2024-02-05T10:41:49Z " -o out/container-structure-test-linux-arm64 github.com/GoogleContainerTools/container-structure-test/cmd/container-structure-test
shasum -a 256 out/container-structure-test-linux-arm64 &> out/container-structure-test-linux-arm64.sha256
shasum -a 256 out/container-structure-test-darwin-arm64 &> out/container-structure-test-darwin-arm64.sha256
/Users/nate.gay/bin/docker build -t gcr.io/gcp-runtimes/container-structure-test:latest .
[+] Building 3.7s (7/7) FINISHED                                                                                                              docker
 => [internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 154B                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                          1.4s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                          0.0s
 => [internal] load build context                                                                                                                        0.1s
 => => transferring context: 15.49MB                                                                                                                     0.1s
 => [1/2] FROM docker.io/library/ubuntu:20.04@sha256:bb1c41682308d7040f74d103022816d41c50d7b0c89e9d706a74b4e548636e54                                    2.1s
 => => resolve docker.io/library/ubuntu:20.04@sha256:bb1c41682308d7040f74d103022816d41c50d7b0c89e9d706a74b4e548636e54                                    0.0s
 => => sha256:bb1c41682308d7040f74d103022816d41c50d7b0c89e9d706a74b4e548636e54 1.13kB / 1.13kB                                                           0.0s
 => => sha256:175ee225697a668b782a54a56f090c046584f06a93c1bae990972e4f1bf6e4ac 424B / 424B                                                               0.0s
 => => sha256:f8b1498b9544ea65cbf02fb2feb0eea5a8af4f02097cb5447ec566061ff245c0 2.31kB / 2.31kB                                                           0.0s
 => => sha256:bc5b5b7ccd1e19c62fdfc4688b98b69619822aab7431a47a392d5795347d854f 25.98MB / 25.98MB                                                         1.2s
 => => extracting sha256:bc5b5b7ccd1e19c62fdfc4688b98b69619822aab7431a47a392d5795347d854f                                                                0.9s
 => [2/2] ADD out/container-structure-test /container-structure-test                                                                                     0.1s
 => exporting to image                                                                                                                                   0.0s
 => => exporting layers                                                                                                                                  0.0s
 => => writing image sha256:a5a490999311b89518d82867827b752b089a69530063f43a29809b61c64cc7a4                                                             0.0s
 => => naming to gcr.io/gcp-runtimes/container-structure-test:latest                                                                                     0.0s

###############
# Positive Test Case
###############

PASS: Success test case passed

###############
# Container Run Options Test Cases
###############

PASS: Run option (user) test case passed
PASS: Run options (capabilities, bindMounts) test case passed
PASS: Run options (envVars) test case passed
PASS: Run options (envFile) test case passed

###############
# Metadata Test Case
###############

PASS: Metadata success test case for docker driver
PASS: Metadata success test case for tar driver
PASS: Metadata success test case for host driver

###############
# Failure Test Case
###############

FATA[0000] FAIL
PASS: Failure test failed

###############
# OCI layout test case
###############

PASS: oci failing test case
PASS: oci success test case

###############
# Platform test cases
###############

Unable to find image 'tonistiigi/binfmt:latest' locally
latest: Pulling from tonistiigi/binfmt
6dda554f4baf: Pull complete
2b0720d7a501: Pull complete
Digest: sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55
Status: Downloaded newer image for tonistiigi/binfmt:latest
installing: mips64 OK
PASS: current host platform test case
PASS: platform failing test case
PASS: platform w/ --pull test case
```

Would close https://github.com/GoogleContainerTools/container-structure-test/issues/410