### PR TITLE
Use goreleaser to autopopulate releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      packages: write
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v5
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ structure_tests.test
 .vscode
 out/
 bazel-*
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,56 @@
+project_name: container-structure-test
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+
+    main: ./cmd/container-structure-test
+
+    binary: container-structure-test-{{.Os}}-{{.Arch}}
+
+    ldflags:
+      - -X github.com/GoogleContainerTools/container-structure-test/pkg/version.version=12
+      - -X github.com/GoogleContainerTools/container-structure-test/pkg/version.buildDate={{.Date}}
+      - -X github.com/GoogleContainerTools/container-structure-test/pkg/version.builtBy=goreleaser
+      - -X github.com/GoogleContainerTools/container-structure-test/pkg/version.commit={{.Commit}}
+
+    targets:
+      - darwin_amd64
+      - darwin_arm64
+      - linux_amd64
+      - linux_arm64
+      - linux_s390x
+      - linux_ppc64le
+      - windows_amd64
+
+    no_unique_dist_dir: true
+
+checksum:
+  name_template: "checksums.txt"
+
+archives:
+  - format: binary
+    name_template: "{{ .Binary }}"
+
+kos:
+  - repository: ghcr.io/GoogleContainerTools/container-structure-test
+    base_image: ubuntu:22.04
+    tags:
+      - '{{.Version}}'
+      - latest
+    bare: true
+    preserve_import_paths: false
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    ldflags:
+      - -X github.com/GoogleContainerTools/container-structure-test/pkg/version.version=12
+      - -X github.com/GoogleContainerTools/container-structure-test/pkg/version.buildDate={{.Date}}
+      - -X github.com/GoogleContainerTools/container-structure-test/pkg/version.builtBy=goreleaser
+      - -X github.com/GoogleContainerTools/container-structure-test/pkg/version.commit={{.Commit}}
+
+release:
+  footer: |
+    ## Container Images
+
+    `ghcr.io/GoogleContainerTools/container-structure-test:{{.Version}}`


### PR DESCRIPTION
This should autopopulate releases with binaries, I don't know how this affects the bazel X.X.1 release shenanigans tough

After the first release of a container we need to make the package public.