### PR TITLE
fix: unmask loading errors

### DIFF
--- a/bazel/container_structure_test.bzl
+++ b/bazel/container_structure_test.bzl
@@ -54,7 +54,6 @@ def _structure_test_impl(ctx):
         if ctx.attr.driver != "docker":
             fail("when the 'driver' attribute is not 'docker', then the image must be a .tar file")
         fixed_args.extend(["--image-from-oci-layout", "$(rlocation %s)" % image_path])
-        fixed_args.extend(["--default-image-tag", "registry.structure_test.oci.local/image:$DIGEST"])
 
     for arg in ctx.files.configs:
         fixed_args.extend(["--config", "$(rlocation %s)" % to_rlocation_path(ctx, arg)])

--- a/cmd/container-structure-test/app/cmd/test.go
+++ b/cmd/container-structure-test/app/cmd/test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+
 	"github.com/GoogleContainerTools/container-structure-test/cmd/container-structure-test/app/cmd/test"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -150,8 +151,17 @@ func run(out io.Writer) error {
 				logrus.Fatalf("could parse the default image tag %s: %v", opts.DefaultImageTag, err)
 			}
 		}
-		if _, err = daemon.Write(tag, img); err != nil {
+		var r string
+		if r, err = daemon.Write(tag, img); err != nil {
 			logrus.Fatalf("error loading oci layout into daemon: %v, %s", err)
+		}
+		// For some reason, daemon.Write doesn't return errors for some edge cases.
+		// We should always print what the daemon sent back so that errors are transparent.
+		fmt.Println("Loaded ", tag.String(), r)
+
+		_, err = daemon.Image(tag)
+		if err != nil {
+			logrus.Fatalf("error loading oci layout into daemon: %v", err)
 		}
 
 		opts.ImagePath = tag.String()


### PR DESCRIPTION
For some reason daemon.Write does not return error when docker daemon clearly indicates failure. This change does not fix daemon.Write but prints the result returned by the daemon and does an additional probe to see if image got loaded successfully before proceeding to test. 