### PR TITLE
fix: add option to ignore ref annotation

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,13 +5,6 @@ on: [push, pull_request]
 
 permissions: read-all
 
-concurrency:
-  # On master/release, we don't want any jobs cancelled
-  # On PR branches, we cancel the job if new commits are pushed
-  # More info: https://stackoverflow.com/a/70972844/1261287
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
-
 jobs:
   build:
     name: PR unit tests

--- a/bazel/container_structure_test.bzl
+++ b/bazel/container_structure_test.bzl
@@ -33,7 +33,7 @@ readonly image=$(rlocation {image_path})
 # When the image points to a folder, we can read the index.json file inside
 if [[ -d "$image" ]]; then
   readonly DIGEST=$("$jq" -r '.manifests[0].digest | sub(":"; "-")' "$image/index.json")
-  exec "$st" test --driver {driver} {fixed_args} --default-image-tag "registry.structure_test.oci.local/image:$DIGEST" $@
+  exec "$st" test --driver {driver} {fixed_args} --default-image-tag "cst.oci.local/$DIGEST:$DIGEST" $@
 else
   exec "$st" test --driver {driver} {fixed_args} $@
 fi
@@ -53,7 +53,7 @@ def _structure_test_impl(ctx):
         # https://github.com/GoogleContainerTools/container-structure-test/blob/5e347b66fcd06325e3caac75ef7dc999f1a9b614/cmd/container-structure-test/app/cmd/test.go#L110
         if ctx.attr.driver != "docker":
             fail("when the 'driver' attribute is not 'docker', then the image must be a .tar file")
-        fixed_args.extend(["--image-from-oci-layout", "$(rlocation %s)" % image_path])
+        fixed_args.extend(["--ignore-ref-annotation", "--image-from-oci-layout", "$(rlocation %s)" % image_path])
 
     for arg in ctx.files.configs:
         fixed_args.extend(["--config", "$(rlocation %s)" % to_rlocation_path(ctx, arg)])

--- a/cmd/container-structure-test/app/cmd/test.go
+++ b/cmd/container-structure-test/app/cmd/test.go
@@ -137,7 +137,7 @@ func run(out io.Writer) error {
 		var tag name.Tag
 
 		ref := desc.Annotations[v1.AnnotationRefName]
-		if ref != "" {
+		if ref != "" && !opts.IgnoreRefAnnotation {
 			tag, err = name.NewTag(ref)
 			if err != nil {
 				logrus.Fatalf("could not parse ref annotation %s: %v", v1.AnnotationRefName, err)
@@ -231,6 +231,7 @@ func AddTestFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&opts.ImagePath, "image", "i", "", "path to test image")
 	cmd.Flags().StringVar(&opts.ImageFromLayout, "image-from-oci-layout", "", "path to the oci layout to test against")
 	cmd.Flags().StringVar(&opts.DefaultImageTag, "default-image-tag", "", "default image tag to used when loading images to the daemon. required when --image-from-oci-layout refers to a oci layout lacking the reference annotation.")
+	cmd.Flags().BoolVar(&opts.IgnoreRefAnnotation, "ignore-ref-annotation", false, "ignore the org.opencontainers.image.ref.name and use --default-image-tag when loading to daemon")
 	cmd.MarkFlagsMutuallyExclusive("image", "image-from-oci-layout")
 	cmd.Flags().StringVarP(&opts.Driver, "driver", "d", "docker", "driver to use when running tests")
 	cmd.Flags().StringVar(&opts.Metadata, "metadata", "", "path to image metadata file")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -17,15 +17,16 @@ package config
 import "github.com/GoogleContainerTools/container-structure-test/pkg/types/unversioned"
 
 type StructureTestOptions struct {
-	ImagePath       string
-	ImageFromLayout string
-	DefaultImageTag string
-	Driver          string
-	Runtime         string
-	Platform        string
-	Metadata        string
-	TestReport      string
-	ConfigFiles     []string
+	ImagePath           string
+	ImageFromLayout     string
+	DefaultImageTag     string
+	IgnoreRefAnnotation bool
+	Driver              string
+	Runtime             string
+	Platform            string
+	Metadata            string
+	TestReport          string
+	ConfigFiles         []string
 
 	JSON    bool
 	Output  unversioned.OutputValue


### PR DESCRIPTION
This fixes issue where when two image containing same `org.opencontainers.image.ref.name` annotation lead to random failures when running simultaneously.  This introduces a new flag to ignore those annotations which is the default for bazel rules. 