### PR TITLE
Enable Darwin ARM64 binaries to be used in Bazel

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -31,11 +31,7 @@ structure_test_toolchain(
 def _structure_test_repo_impl(repository_ctx):
     platform = repository_ctx.attr.platform.replace("_", "-")
 
-    # There is no arm64 version of structure test binary.
-    # TODO: remove this after we start publishing one.
-    if platform.find("darwin") != -1:
-        platform = platform.replace("arm64", "amd64")
-    elif platform.find("windows") != -1:
+    if platform.find("windows") != -1:
         platform = platform + ".exe"
     url = "https://github.com/GoogleContainerTools/container-structure-test/releases/download/{version}/container-structure-test-{platform}".format(
         version = _VERSION,


### PR DESCRIPTION
# Context 

I've been trying to use `container-structure-test` via Bazel on a Darwin ARM64 machine without Rosetta and kept having the error:

```log
==================== Test output for //:structure:
/private/var/tmp/_bazel_drb/90c1aedef04b4dc3f5392ec26da69ab7/sandbox/darwin-sandbox/321/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/structure.sh.runfiles/_main/structure.sh: line 24
: /private/var/tmp/_bazel_drb/90c1aedef04b4dc3f5392ec26da69ab7/sandbox/darwin-sandbox/321/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/structure.sh.runfiles/container_structure_test~~extension~structu
re_test_st_darwin_arm64/structure_test: Bad CPU type in executable
================================================================================
```

Double checking with:

```log
❯ file bazel-out/darwin_arm64-fastbuild/bin/structure.sh.runfiles/container_structure_test\~\~extension\~structure_test_st_darwin_arm64/structure_test 
bazel-out/darwin_arm64-fastbuild/bin/structure.sh.runfiles/container_structure_test~~extension~structure_test_st_darwin_arm64/structure_test: Mach-O 64-bit executable x86_64
```

I validated that the toolchains were correct by adding `--toolchain_resolution_debug='.*'` to the `bazel test` execution

```log
INFO: ToolchainResolution: Performing resolution of @@container_structure_test~//bazel:structure_test_toolchain_type for target platform @@local_config_platform//:host
      ToolchainResolution:   Toolchain @@container_structure_test~~extension~structure_test_st_darwin_amd64//:structure_test_toolchain is compatible with target plaform, searching for execution platforms:
      ToolchainResolution:     Incompatible execution platform @@local_config_platform//:host; mismatching values: x86_64
      ToolchainResolution:   Toolchain @@container_structure_test~~extension~structure_test_st_darwin_arm64//:structure_test_toolchain is compatible with target plaform, searching for execution platforms:
      ToolchainResolution:     Compatible execution platform @@local_config_platform//:host
      ToolchainResolution:   All execution platforms have been assigned a @@container_structure_test~//bazel:structure_test_toolchain_type toolchain, stopping
      ToolchainResolution: Recap of selected @@container_structure_test~//bazel:structure_test_toolchain_type toolchains for target platform @@local_config_platform//:host:
      ToolchainResolution:   Selected @@container_structure_test~~extension~structure_test_st_darwin_arm64//:structure_test_toolchain to run on execution platform @@local_config_platform//:host
INFO: ToolchainResolution: Target platform @@local_config_platform//:host: Selected execution platform @@local_config_platform//:host, type @@aspect_bazel_lib~//lib:jq_toolchain_type -> toolchain @@aspect_bazel_lib~~toolchain
s~jq_darwin_arm64//:jq_toolchain, type @@bazel_tools//tools/sh:toolchain_type -> toolchain @@bazel_tools~sh_configure_extension~local_config_sh//:local_sh, type @@container_structure_test~//bazel:structure_test_toolchain_type
 -> toolchain @@container_structure_test~~extension~structure_test_st_darwin_arm64//:structure_test_toolchain
```

After a lot of head scratching I came across this `TODO` comment, I have patched this out locally in my bazel workspace and it finally runs using the right architecture and the tests run & pass.

```log
❯ file bazel-out/darwin_arm64-fastbuild/bin/structure.sh.runfiles/container_structure_test\~\~extension\~structure_test_st_darwin_arm64/structure_test 
bazel-out/darwin_arm64-fastbuild/bin/structure.sh.runfiles/container_structure_test~~extension~structure_test_st_darwin_arm64/structure_test: Mach-O 64-bit executable arm64
```

## Side-note

If this patch is accepted and a new release tag is published: Can the Bazel Registry version also be bumped as well 🙏?