### PR TITLE
Remove linux_i386 from Bazel setup

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,6 @@ use_repo(
     "structure_test_st_darwin_amd64",
     "structure_test_st_darwin_arm64",
     "structure_test_st_linux_arm64",
-    "structure_test_st_linux_i386",
     "structure_test_st_linux_s390x",
     "structure_test_st_linux_amd64",
     "structure_test_st_windows_amd64",

--- a/bazel/toolchains_repo.bzl
+++ b/bazel/toolchains_repo.bzl
@@ -38,12 +38,6 @@ PLATFORMS = {
             "@platforms//cpu:aarch64",
         ],
     ),
-    "linux_i386": struct(
-        compatible_with = [
-            "@platforms//os:linux",
-            "@platforms//cpu:x86_32",
-        ],
-    ),
     "linux_s390x": struct(
         compatible_with = [
             "@platforms//os:linux",


### PR DESCRIPTION
There is no binary published for linux/i386, causing failures in some situations when depending on this module.

Fixes https://github.com/GoogleContainerTools/container-structure-test/issues/409