### PR TITLE
Skip creating new image if env is empty

### DIFF
--- a/pkg/drivers/docker_driver.go
+++ b/pkg/drivers/docker_driver.go
@@ -98,6 +98,9 @@ func (d *DockerDriver) Destroy() {
 }
 
 func (d *DockerDriver) SetEnv(envVars []unversioned.EnvVar) error {
+	if len(envVars) == 0 {
+		return nil
+	}
 	env := d.processEnvVars(envVars)
 	container, err := d.cli.CreateContainer(docker.CreateContainerOptions{
 		Platform: d.platform,


### PR DESCRIPTION
The docker driver always creates a new container + image in [`Setup`](https://github.com/GoogleContainerTools/container-structure-test/blob/9894abb7becc658a3952e1bc249437fc479bc067/pkg/drivers/docker_driver.go#L100C6-L100C9), which for large images causes a long delay during [`Destroy` ](https://github.com/GoogleContainerTools/container-structure-test/blob/9894abb7becc658a3952e1bc249437fc479bc067/pkg/drivers/docker_driver.go#L94). For my image with a simple test that checks for the exit code, skipping the new image creation when there is no env saves 3min of execution time:

Before: `container-structure-test -v debug test -c  -i   0.03s user 0.03s system 0% cpu 3:26.83 total`
After: `container-structure-test -v debug test -c  -i   0.03s user 0.01s system 0% cpu 14.933 total`