### PR TITLE
Add support for specifying sysctls in run options

### DIFF
--- a/bazel/test/test.yaml
+++ b/bazel/test/test.yaml
@@ -6,3 +6,8 @@ metadataTest:
       value: "/test"
   entrypoint: ["/custom_bin"]
   cmd: ["--arg1", "--arg2"]
+
+containerRunOptions:
+  sysctls:
+    net.core.somaxconn: "1024"
+    net.ipv4.tcp_max_syn_backlog: "4096"

--- a/pkg/drivers/docker_driver.go
+++ b/pkg/drivers/docker_driver.go
@@ -19,13 +19,13 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/joho/godotenv"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/joho/godotenv"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -69,6 +69,7 @@ func (d *DockerDriver) hostConfig() *docker.HostConfig {
 			Capabilities: d.runOpts.Capabilities,
 			Binds:        d.runOpts.BindMounts,
 			Privileged:   d.runOpts.Privileged,
+			Sysctls:      d.runOpts.Sysctls,
 			Runtime:      d.runtime,
 		}
 	}
@@ -77,6 +78,7 @@ func (d *DockerDriver) hostConfig() *docker.HostConfig {
 			Capabilities: d.runOpts.Capabilities,
 			Binds:        d.runOpts.BindMounts,
 			Privileged:   d.runOpts.Privileged,
+			Sysctls:      d.runOpts.Sysctls,
 		}
 	}
 	if d.runtime != "" {

--- a/pkg/types/unversioned/types.go
+++ b/pkg/types/unversioned/types.go
@@ -47,9 +47,10 @@ type Config struct {
 type ContainerRunOptions struct {
 	User         string
 	Privileged   bool
-	TTY          bool     `yaml:"allocateTty"`
-	EnvVars      []string `yaml:"envVars"`
-	EnvFile      string   `yaml:"envFile"`
+	TTY          bool              `yaml:"allocateTty"`
+	EnvVars      []string          `yaml:"envVars"`
+	EnvFile      string            `yaml:"envFile"`
+	Sysctls      map[string]string `yaml:"sysctls"`
 	Capabilities []string
 	BindMounts   []string `yaml:"bindMounts"`
 }
@@ -61,7 +62,8 @@ func (opts *ContainerRunOptions) IsSet() bool {
 		len(opts.EnvFile) > 0 ||
 		(opts.EnvVars != nil && len(opts.EnvVars) > 0) ||
 		(opts.Capabilities != nil && len(opts.Capabilities) > 0) ||
-		(opts.BindMounts != nil && len(opts.BindMounts) > 0)
+		(opts.BindMounts != nil && len(opts.BindMounts) > 0) ||
+		len(opts.Sysctls) > 0
 }
 
 type TestResult struct {


### PR DESCRIPTION
This adds a new "Sysctls" field to the ContainerRunOptions struct. This matches the go-dockerclient definition and just gets passed through to the docker HostConfig struct as-is.

Hopefully this is a relatively uncontroversial change.