### PR TITLE
Add support for multi-arch image indexes

### DIFF
--- a/tests/amd64/fluent_bit_test.yaml
+++ b/tests/amd64/fluent_bit_test.yaml
@@ -1,0 +1,19 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+commandTests:
+- name: 'fluent-bit'
+  command: '/fluent-bit/bin/fluent-bit'
+  args: ['--version']
+  expectedOutput: ['Fluent Bit v4.0.4']
+fileContentTests:
+- name: 'Passwd file'
+  expectedContents: ['root:x:0:0:root:/root:/sbin/nologin']
+  path: '/etc/passwd'
+fileExistenceTests:
+- name: 'Root'
+  path: '/'
+  shouldExist: true
+  uid: 0
+  gid: 0
+- name: 'libc'
+  path: '/lib/x86_64-linux-gnu/libc.so.6'
+  shouldExist: true

--- a/tests/arm64/fluent_bit_test.yaml
+++ b/tests/arm64/fluent_bit_test.yaml
@@ -1,0 +1,19 @@
+schemaVersion: '2.0.0' # Make sure to test the latest schema version
+commandTests:
+- name: 'fluent-bit'
+  command: '/fluent-bit/bin/fluent-bit'
+  args: ['--version']
+  expectedOutput: ['Fluent Bit v4.0.4']
+fileContentTests:
+- name: 'Passwd file'
+  expectedContents: ['root:x:0:0:root:/root:/sbin/nologin']
+  path: '/etc/passwd'
+fileExistenceTests:
+- name: 'Root'
+  path: '/'
+  shouldExist: true
+  uid: 0
+  gid: 0
+- name: 'libc'
+  path: '/lib/aarch64-linux-gnu/libc.so.6'
+  shouldExist: true


### PR DESCRIPTION
The image loaded is based on the platform flag passed to the structure test
binary, which defaults to linux/GOARCH. On hosts that are multi-platform
capable, specifying an different platform flag will result in an alternate
image being loaded from the index.

Fixes #435